### PR TITLE
feat: ホットリロード機能とトグル即時反映を実装

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Gittohabu",
   "version": "0.0.0",
   "description": "GitHub向けChrome拡張の雛形",
-  "permissions": ["storage"],
+  "permissions": ["storage", "activeTab", "tabs"],
   "content_scripts": [
     {
       "matches": ["https://github.com/*"],

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,7 +1,13 @@
 import { loadDictionary, getReplaceEntries, getHoverEntries } from '../dictionary/loader';
 import { startObserver, stopObserver } from './observer';
-import { isReplaceEnabled, replaceAll, setEnabled, setReplaceEntries } from './replacer';
+import { isReplaceEnabled, replaceAll, restoreAll, hotReload, setEnabled, setReplaceEntries } from './replacer';
 import { setHoverEntries, setHoverEnabled } from './hover';
+
+/** メッセージの型定義 */
+interface GittohaubuMessage {
+  type: 'toggle' | 'hotReload' | 'getStatus';
+  enabled?: boolean;
+}
 
 async function init(): Promise<void> {
   console.log('[gittohabu] Initializing...');
@@ -62,21 +68,14 @@ function loadEnabledState(): Promise<boolean> {
 async function start(): Promise<void> {
   await init();
 
+  // ストレージ変更リスナー
   chrome.storage.onChanged.addListener((changes) => {
     if (changes.gittohabu_enabled) {
       const enabled = changes.gittohabu_enabled.newValue;
       if (typeof enabled !== 'boolean') {
         return;
       }
-      setEnabled(enabled);
-      setHoverEnabled(enabled);
-
-      if (enabled) {
-        replaceAll();
-        startObserver();
-      } else {
-        stopObserver();
-      }
+      handleToggle(enabled);
     }
     if (changes.gittohabu_user_dictionary) {
       refreshDictionary().catch((error) => {
@@ -84,6 +83,48 @@ async function start(): Promise<void> {
       });
     }
   });
+
+  // メッセージリスナー（即時反映用）
+  chrome.runtime.onMessage.addListener(
+    (message: GittohaubuMessage, _sender, sendResponse) => {
+      switch (message.type) {
+        case 'toggle':
+          if (typeof message.enabled === 'boolean') {
+            handleToggle(message.enabled);
+          }
+          sendResponse({ success: true });
+          break;
+        case 'hotReload':
+          hotReload();
+          sendResponse({ success: true });
+          break;
+        case 'getStatus':
+          sendResponse({ enabled: isReplaceEnabled() });
+          break;
+        default:
+          sendResponse({ success: false, error: 'Unknown message type' });
+      }
+      return true; // 非同期レスポンスを許可
+    },
+  );
+}
+
+/**
+ * トグル状態を即座に反映
+ */
+function handleToggle(enabled: boolean): void {
+  setEnabled(enabled);
+  setHoverEnabled(enabled);
+
+  if (enabled) {
+    replaceAll();
+    startObserver();
+    console.log('[gittohabu] 有効化しました');
+  } else {
+    stopObserver();
+    restoreAll();
+    console.log('[gittohabu] 無効化しました（テキストを元に戻しました）');
+  }
 }
 
 start().catch((error) => {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -3,10 +3,9 @@ import { startObserver, stopObserver } from './observer';
 import { isReplaceEnabled, replaceAll, restoreAll, hotReload, setEnabled, setReplaceEntries } from './replacer';
 import { setHoverEntries, setHoverEnabled } from './hover';
 
-/** メッセージの型定義 */
+/** メッセージの型定義（hotReload と getStatus のみ、toggle は storage.onChanged で処理） */
 interface GittohabulMessage {
-  type: 'toggle' | 'hotReload' | 'getStatus';
-  enabled?: boolean;
+  type: 'hotReload' | 'getStatus';
 }
 
 async function init(): Promise<void> {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -4,7 +4,7 @@ import { isReplaceEnabled, replaceAll, restoreAll, hotReload, setEnabled, setRep
 import { setHoverEntries, setHoverEnabled } from './hover';
 
 /** メッセージの型定義 */
-interface GittohaubuMessage {
+interface GittohabulMessage {
   type: 'toggle' | 'hotReload' | 'getStatus';
   enabled?: boolean;
 }
@@ -84,16 +84,10 @@ async function start(): Promise<void> {
     }
   });
 
-  // メッセージリスナー（即時反映用）
+  // メッセージリスナー（hotReload と getStatus のみ処理、toggle は storage.onChanged で十分）
   chrome.runtime.onMessage.addListener(
-    (message: GittohaubuMessage, _sender, sendResponse) => {
+    (message: GittohabulMessage, _sender, sendResponse) => {
       switch (message.type) {
-        case 'toggle':
-          if (typeof message.enabled === 'boolean') {
-            handleToggle(message.enabled);
-          }
-          sendResponse({ success: true });
-          break;
         case 'hotReload':
           hotReload();
           sendResponse({ success: true });

--- a/src/content/replacer.ts
+++ b/src/content/replacer.ts
@@ -12,6 +12,12 @@ type CompiledReplaceEntry = {
 /** 置換対象のエントリ一覧 */
 let compiledEntries: CompiledReplaceEntry[] = [];
 
+/** 元のテキストを保持するマップ (WeakMapでメモリリークを防ぐ) */
+const originalTextMap = new WeakMap<Text, string>();
+
+/** 置換済みのテキストノードを追跡 */
+const replacedNodes = new Set<WeakRef<Text>>();
+
 /** 置換が有効かどうか */
 let isEnabled = true;
 
@@ -78,7 +84,12 @@ export function setLanguage(lang: string): void {
 export function replaceTextNode(node: Text): void {
   if (!isEnabled) return;
 
-  const originalText = node.textContent;
+  // 元のテキストを保持（初回のみ）
+  if (!originalTextMap.has(node)) {
+    originalTextMap.set(node, node.textContent ?? '');
+  }
+
+  const originalText = originalTextMap.get(node);
   if (!originalText) return;
 
   let text = originalText;
@@ -103,6 +114,7 @@ export function replaceTextNode(node: Text): void {
 
   if (modified && text !== node.textContent) {
     node.textContent = text;
+    replacedNodes.add(new WeakRef(node));
   }
 }
 
@@ -163,4 +175,44 @@ export function replaceAll(): void {
     return;
   }
   replaceTextInElement(rootElement);
+}
+
+/**
+ * 置換したテキストを元に戻す
+ */
+export function restoreAll(): void {
+  // 追跡しているノードを巡回して元のテキストに戻す
+  for (const weakRef of replacedNodes) {
+    const node = weakRef.deref();
+    if (node && originalTextMap.has(node)) {
+      const original = originalTextMap.get(node);
+      if (original !== undefined && node.textContent !== original) {
+        node.textContent = original;
+      }
+    }
+  }
+  replacedNodes.clear();
+  console.log('[gittohabu] テキストを元に戻しました');
+}
+
+/**
+ * キャッシュをクリアして再適用（ホットリロード）
+ */
+export function hotReload(): void {
+  console.log('[gittohabu] ホットリロード開始...');
+  
+  // 一旦全ての置換を元に戻す
+  restoreAll();
+  
+  // WeakMapのエントリもクリア（新しいノードとして扱う）
+  // WeakMapは直接クリアできないので、replacedNodesをクリアするだけで十分
+  
+  // 有効な場合は再度置換を実行
+  if (isEnabled) {
+    // 少し遅延させてDOMの更新を待つ
+    requestAnimationFrame(() => {
+      replaceAll();
+      console.log('[gittohabu] ホットリロード完了');
+    });
+  }
 }

--- a/src/content/replacer.ts
+++ b/src/content/replacer.ts
@@ -114,7 +114,11 @@ export function replaceTextNode(node: Text): void {
 
   if (modified && text !== node.textContent) {
     node.textContent = text;
-    replacedNodes.add(new WeakRef(node));
+    // 重複チェック：既にこのノードが追跡されているか確認
+    const isAlreadyTracked = Array.from(replacedNodes).some((weakRef) => weakRef.deref() === node);
+    if (!isAlreadyTracked) {
+      replacedNodes.add(new WeakRef(node));
+    }
   }
 }
 
@@ -214,5 +218,8 @@ export function hotReload(): void {
       replaceAll();
       console.log('[gittohabu] ホットリロード完了');
     });
+  } else {
+    // 無効な場合も完了ログを出力
+    console.log('[gittohabu] ホットリロード完了');
   }
 }

--- a/src/content/replacer.ts
+++ b/src/content/replacer.ts
@@ -200,13 +200,13 @@ export function restoreAll(): void {
  */
 export function hotReload(): void {
   console.log('[gittohabu] ホットリロード開始...');
-  
+
   // 一旦全ての置換を元に戻す
   restoreAll();
-  
+
   // WeakMapのエントリもクリア（新しいノードとして扱う）
   // WeakMapは直接クリアできないので、replacedNodesをクリアするだけで十分
-  
+
   // 有効な場合は再度置換を実行
   if (isEnabled) {
     // 少し遅延させてDOMの更新を待つ

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
@@ -7,7 +7,11 @@
     <style>
       :root {
         color-scheme: dark;
-        font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+        font-family:
+          "Segoe UI",
+          system-ui,
+          -apple-system,
+          sans-serif;
       }
 
       body {
@@ -95,7 +99,7 @@
       }
 
       .slider::before {
-        content: '';
+        content: "";
         position: absolute;
         height: 18px;
         width: 18px;
@@ -187,7 +191,12 @@
       </div>
       <div class="status-text" id="status-text">有効</div>
       <div class="spacer"></div>
-      <button id="hot-reload" class="button button-primary" type="button">
+      <button
+        id="hot-reload"
+        class="button button-primary"
+        type="button"
+        aria-label="ページの置換を再読み込み"
+      >
         🔄 再読み込み
       </button>
       <div class="spacer"></div>

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -151,11 +151,20 @@
         border-color: #2ea043;
       }
 
+      .button-primary:focus-visible {
+        outline: 2px solid #58a6ff;
+        outline-offset: 2px;
+      }
+
       .button-primary:disabled {
         background: #21262d;
         border-color: #30363d;
         color: #8b949e;
         cursor: not-allowed;
+      }
+
+      .button-primary:disabled:focus-visible {
+        outline: none;
       }
 
       .button-row {

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -136,6 +136,33 @@
         background: #30363d;
       }
 
+      .button-primary {
+        background: #238636;
+        border-color: #238636;
+        color: #ffffff;
+      }
+
+      .button-primary:hover {
+        background: #2ea043;
+        border-color: #2ea043;
+      }
+
+      .button-primary:disabled {
+        background: #21262d;
+        border-color: #30363d;
+        color: #8b949e;
+        cursor: not-allowed;
+      }
+
+      .button-row {
+        display: flex;
+        gap: 8px;
+      }
+
+      .button-row .button {
+        flex: 1;
+      }
+
       .spacer {
         height: 12px;
       }
@@ -159,6 +186,10 @@
         </label>
       </div>
       <div class="status-text" id="status-text">有効</div>
+      <div class="spacer"></div>
+      <button id="hot-reload" class="button button-primary" type="button">
+        🔄 再読み込み
+      </button>
       <div class="spacer"></div>
       <button id="open-options" class="button" type="button">設定を開く</button>
     </main>

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -10,8 +10,7 @@ const hotReloadButton = document.getElementById('hot-reload') as HTMLButtonEleme
  * GitHubタブにメッセージを送信
  */
 async function sendMessageToGitHubTabs(message: {
-  type: string;
-  enabled?: boolean;
+  type: 'hotReload' | 'getStatus';
 }): Promise<void> {
   try {
     const tabs = await chrome.tabs.query({ url: 'https://github.com/*' });
@@ -67,8 +66,7 @@ toggle?.addEventListener('change', () => {
       return;
     }
     renderStatus(enabled);
-    // 即座にGitHubタブに反映
-    sendMessageToGitHubTabs({ type: 'toggle', enabled });
+    // storage.onChanged で自動的にコンテンツスクリプトへ反映される
   });
 });
 

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -7,23 +7,25 @@ const openOptionsButton = document.getElementById('open-options');
 const hotReloadButton = document.getElementById('hot-reload') as HTMLButtonElement | null;
 
 /**
- * GitHubタブにメッセージを送信
+ * GitHubタブにメッセージを送信（エラーは呼び出し元に伝播）
  */
 async function sendMessageToGitHubTabs(message: {
   type: 'hotReload' | 'getStatus';
 }): Promise<void> {
-  try {
-    const tabs = await chrome.tabs.query({ url: 'https://github.com/*' });
-    for (const tab of tabs) {
-      if (tab.id) {
-        chrome.tabs.sendMessage(tab.id, message).catch(() => {
-          // タブがまだコンテンツスクリプトをロードしていない場合は無視
-        });
-      }
+  const tabs = await chrome.tabs.query({ url: 'https://github.com/*' });
+  const sendPromises: Promise<void>[] = [];
+
+  for (const tab of tabs) {
+    if (tab.id) {
+      const promise = chrome.tabs.sendMessage(tab.id, message).catch((error) => {
+        // タブがまだコンテンツスクリプトをロードしていない場合など
+        console.warn(`[gittohabu] タブ ${tab.id} へのメッセージ送信に失敗:`, error);
+      });
+      sendPromises.push(promise);
     }
-  } catch (error) {
-    console.warn('[gittohabu] タブへのメッセージ送信に失敗:', error);
   }
+
+  await Promise.all(sendPromises);
 }
 
 function renderStatus(enabled: boolean): void {
@@ -70,29 +72,34 @@ toggle?.addEventListener('change', () => {
   });
 });
 
-hotReloadButton?.addEventListener('click', async () => {
-  if (!hotReloadButton) return;
-
-  // ボタンを一時的に無効化
-  hotReloadButton.disabled = true;
-  hotReloadButton.textContent = '⏳ 再読み込み中...';
-
-  try {
-    await sendMessageToGitHubTabs({ type: 'hotReload' });
-    hotReloadButton.textContent = '✅ 完了!';
-    setTimeout(() => {
-      hotReloadButton.disabled = false;
-      hotReloadButton.textContent = '🔄 再読み込み';
-    }, 1000);
-  } catch (error) {
-    console.error('[gittohabu] ホットリロードに失敗:', error);
-    hotReloadButton.textContent = '❌ 失敗';
-    setTimeout(() => {
-      hotReloadButton.disabled = false;
-      hotReloadButton.textContent = '🔄 再読み込み';
-    }, 1000);
+/**
+ * ホットリロードボタンの状態をリセット
+ */
+function restoreHotReloadButton(): void {
+  if (hotReloadButton) {
+    hotReloadButton.disabled = false;
+    hotReloadButton.textContent = '🔄 再読み込み';
   }
-});
+}
+
+if (hotReloadButton) {
+  hotReloadButton.addEventListener('click', async () => {
+    // ボタンを一時的に無効化
+    hotReloadButton.disabled = true;
+    hotReloadButton.textContent = '⏳ 再読み込み中...';
+
+    try {
+      await sendMessageToGitHubTabs({ type: 'hotReload' });
+      hotReloadButton.textContent = '✅ 完了!';
+    } catch (error) {
+      console.error('[gittohabu] ホットリロードに失敗:', error);
+      hotReloadButton.textContent = '❌ 失敗';
+    } finally {
+      // 1秒後にボタンをリセット
+      setTimeout(restoreHotReloadButton, 1000);
+    }
+  });
+}
 
 openOptionsButton?.addEventListener('click', () => {
   if (chrome.runtime.openOptionsPage) {

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -4,6 +4,28 @@ const toggle = document.getElementById('enabled-toggle') as HTMLInputElement | n
 const statusPill = document.getElementById('status-pill');
 const statusText = document.getElementById('status-text');
 const openOptionsButton = document.getElementById('open-options');
+const hotReloadButton = document.getElementById('hot-reload') as HTMLButtonElement | null;
+
+/**
+ * GitHubタブにメッセージを送信
+ */
+async function sendMessageToGitHubTabs(message: {
+  type: string;
+  enabled?: boolean;
+}): Promise<void> {
+  try {
+    const tabs = await chrome.tabs.query({ url: 'https://github.com/*' });
+    for (const tab of tabs) {
+      if (tab.id) {
+        chrome.tabs.sendMessage(tab.id, message).catch(() => {
+          // タブがまだコンテンツスクリプトをロードしていない場合は無視
+        });
+      }
+    }
+  } catch (error) {
+    console.warn('[gittohabu] タブへのメッセージ送信に失敗:', error);
+  }
+}
 
 function renderStatus(enabled: boolean): void {
   if (toggle) {
@@ -45,7 +67,33 @@ toggle?.addEventListener('change', () => {
       return;
     }
     renderStatus(enabled);
+    // 即座にGitHubタブに反映
+    sendMessageToGitHubTabs({ type: 'toggle', enabled });
   });
+});
+
+hotReloadButton?.addEventListener('click', async () => {
+  if (!hotReloadButton) return;
+
+  // ボタンを一時的に無効化
+  hotReloadButton.disabled = true;
+  hotReloadButton.textContent = '⏳ 再読み込み中...';
+
+  try {
+    await sendMessageToGitHubTabs({ type: 'hotReload' });
+    hotReloadButton.textContent = '✅ 完了!';
+    setTimeout(() => {
+      hotReloadButton.disabled = false;
+      hotReloadButton.textContent = '🔄 再読み込み';
+    }, 1000);
+  } catch (error) {
+    console.error('[gittohabu] ホットリロードに失敗:', error);
+    hotReloadButton.textContent = '❌ 失敗';
+    setTimeout(() => {
+      hotReloadButton.disabled = false;
+      hotReloadButton.textContent = '🔄 再読み込み';
+    }, 1000);
+  }
 });
 
 openOptionsButton?.addEventListener('click', () => {


### PR DESCRIPTION
## 概要

拡張機能のON/OFFトグルが即座に反映されない問題と、GitHubのキャッシュによる表示不整合を解決するためのホットリロード機能を実装しました。

## 変更内容

### 🔄 ホットリロード機能
- `replacer.ts` に `hotReload()` 関数を追加
- ポップアップに「🔄 再読み込み」ボタンを追加
- ページを完全にリロードせずに、置換を再適用可能に

### ⚡ トグル即時反映
- トグルOFF時に置換テキストを元に戻す `restoreAll()` を実装
- `WeakMap` で元のテキストを保持（メモリリークを防止）
- `chrome.runtime.sendMessage` で即座にコンテンツスクリプトへ通知

### 📦 その他の変更
- `manifest.json` に `activeTab` と `tabs` 権限を追加
- メッセージリスナーを追加してポップアップとコンテンツスクリプト間の通信を実装

## 技術的な詳細

```typescript
// 元のテキストをWeakMapで保持
const originalTextMap = new WeakMap<Text, string>();
const replacedNodes = new Set<WeakRef<Text>>();

// ホットリロード処理
export function hotReload(): void {
  restoreAll();  // 一旦全て元に戻す
  if (isEnabled) {
    requestAnimationFrame(() => replaceAll());  // 再度置換
  }
}
```

## テスト方法
1. 拡張機能をビルドしてChromeにロード
2. GitHubページを開く
3. ポップアップからトグルをOFFにする → テキストが即座に元に戻ることを確認
4. トグルをONにする → テキストが即座に置換されることを確認
5. 「🔄 再読み込み」ボタンをクリック → 置換が再適用されることを確認