### PR TITLE
feat: Comprehensive Ctrl+hover entries for all GitHub UI

### DIFF
--- a/src/dictionary/entries/actions-workflow.ts
+++ b/src/dictionary/entries/actions-workflow.ts
@@ -751,4 +751,286 @@ export const actionsWorkflowEntries: DictionaryEntry[] = [
             ja: '依存関係を自動で監視・更新するGitHubの機能。セキュリティ脆弱性の検出とバージョン更新PRの自動作成を行います。',
         },
     },
+    // ワークフロー実行
+    {
+        type: 'hover',
+        id: 'hover-actions-run-workflow',
+        selector: '.js-run-workflow-form, [data-testid="run-workflow"]',
+        title: { ja: 'ワークフローを実行' },
+        description: {
+            ja: '手動でワークフローを実行します。workflow_dispatchイベントで定義されたワークフローで使用可能です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-rerun',
+        selector: '.js-rerun-workflow, [data-testid="re-run-jobs"]',
+        title: { ja: '再実行' },
+        description: {
+            ja: 'ワークフローを再度実行します。すべてのジョブまたは失敗したジョブのみを選択できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-cancel',
+        selector: '.js-cancel-workflow-run, [data-testid="cancel-run"]',
+        title: { ja: '実行をキャンセル' },
+        description: {
+            ja: '進行中のワークフロー実行を中断します。',
+        },
+    },
+    // ワークフロー一覧
+    {
+        type: 'hover',
+        id: 'hover-actions-workflow-list',
+        selector: '.js-workflow-list, .filter-list',
+        title: { ja: 'ワークフロー一覧' },
+        description: {
+            ja: 'リポジトリに定義されたすべてのワークフロー。各ワークフローの実行履歴を確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-all-workflows',
+        selector: 'a[href*="/actions"][href*="workflows"]',
+        title: { ja: 'すべてのワークフロー' },
+        description: {
+            ja: 'リポジトリ内のすべてのワークフロー実行を一覧表示します。',
+        },
+    },
+    // 実行ステータス
+    {
+        type: 'hover',
+        id: 'hover-actions-status-success',
+        selector: '.octicon-check-circle, [data-testid="status-success"]',
+        title: { ja: '成功' },
+        description: {
+            ja: 'ワークフローまたはジョブが正常に完了しました。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-status-failure',
+        selector: '.octicon-x-circle, [data-testid="status-failure"]',
+        title: { ja: '失敗' },
+        description: {
+            ja: 'ワークフローまたはジョブが失敗しました。ログを確認してエラーを特定してください。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-status-pending',
+        selector: '.octicon-pending, [data-testid="status-pending"]',
+        title: { ja: '待機中' },
+        description: {
+            ja: 'ワークフローまたはジョブがキューで実行待ちです。ランナーが空くと実行されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-status-inprogress',
+        selector: '.octicon-sync, [data-testid="status-in-progress"]',
+        title: { ja: '進行中' },
+        description: {
+            ja: 'ワークフローまたはジョブが現在実行中です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-status-cancelled',
+        selector: '.octicon-stop, [data-testid="status-cancelled"]',
+        title: { ja: 'キャンセル済み' },
+        description: {
+            ja: 'ワークフロー実行が手動でキャンセルされました。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-status-skipped',
+        selector: '.octicon-skip, [data-testid="status-skipped"]',
+        title: { ja: 'スキップ' },
+        description: {
+            ja: '条件が満たされずジョブがスキップされました。if文やneeds条件による制御です。',
+        },
+    },
+    // ログ
+    {
+        type: 'hover',
+        id: 'hover-actions-logs',
+        selector: '.js-workflow-run-logs, [data-testid="logs"]',
+        title: { ja: 'ログ' },
+        description: {
+            ja: 'ワークフロー実行の詳細ログ。各ステップの出力を確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-log-download',
+        selector: '.js-download-workflow-log, [aria-label*="Download logs"]',
+        title: { ja: 'ログをダウンロード' },
+        description: {
+            ja: 'ワークフローのログファイルをZIP形式でダウンロードします。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-log-search',
+        selector: '.js-search-workflow-log, [data-testid="log-search"]',
+        title: { ja: 'ログを検索' },
+        description: {
+            ja: 'ログ内のテキストを検索します。エラーメッセージの特定に便利です。',
+        },
+    },
+    // ジョブ詳細
+    {
+        type: 'hover',
+        id: 'hover-actions-job-summary',
+        selector: '.js-job-summary, [data-testid="job-summary"]',
+        title: { ja: 'ジョブサマリー' },
+        description: {
+            ja: 'ジョブの概要情報。実行時間、ステータス、使用したランナーなどを表示します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-step',
+        selector: '.js-workflow-step, [class*="step-"]',
+        title: { ja: 'ステップ' },
+        description: {
+            ja: 'ジョブ内の個別のタスク。runコマンドやactionsの実行単位です。',
+        },
+    },
+    // ランナー詳細
+    {
+        type: 'hover',
+        id: 'hover-actions-self-hosted',
+        selector: 'a[href*="/settings/actions/runners/new"]',
+        title: { ja: 'セルフホストランナー' },
+        description: {
+            ja: '自分で管理するマシン上で実行するランナー。カスタム環境や特殊なハードウェアが必要な場合に使用します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-github-hosted',
+        selector: '[data-testid="github-hosted-runner"]',
+        title: { ja: 'GitHubホストランナー' },
+        description: {
+            ja: 'GitHubが提供する仮想マシン。Ubuntu、Windows、macOSが利用可能で、毎回クリーンな環境です。',
+        },
+    },
+    // 変数・シークレット
+    {
+        type: 'hover',
+        id: 'hover-actions-variables',
+        selector: 'a[href*="/settings/variables"]',
+        title: { ja: '変数' },
+        description: {
+            ja: 'ワークフローで使用する設定値。シークレットと異なり、ログに表示されます。環境ごとに設定可能です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-environments',
+        selector: 'a[href*="/settings/environments"]',
+        title: { ja: '環境' },
+        description: {
+            ja: 'デプロイ先の環境（production、stagingなど）。環境別のシークレット、承認ルール、待機時間を設定できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-env-protection',
+        selector: '.js-environment-protection, [data-testid="protection-rules"]',
+        title: { ja: '保護ルール' },
+        description: {
+            ja: '環境へのデプロイに必要なルール。レビュアーの承認、待機時間、ブランチ制限などを設定できます。',
+        },
+    },
+    // キャッシュ
+    {
+        type: 'hover',
+        id: 'hover-actions-caches',
+        selector: 'a[href*="/actions/caches"]',
+        title: { ja: 'キャッシュ' },
+        description: {
+            ja: 'ワークフローで使用する依存関係のキャッシュ。ビルド時間を短縮できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-cache-delete',
+        selector: '.js-delete-cache, [data-testid="delete-cache"]',
+        title: { ja: 'キャッシュを削除' },
+        description: {
+            ja: 'キャッシュを手動で削除します。古いキャッシュが問題を起こす場合に使用します。',
+        },
+    },
+    // セキュリティ
+    {
+        type: 'hover',
+        id: 'hover-actions-code-scanning',
+        selector: 'a[href*="/security/code-scanning"]',
+        title: { ja: 'コードスキャン' },
+        description: {
+            ja: 'コード内のセキュリティ脆弱性を自動検出。CodeQLなどの分析ツールを使用します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-secret-scanning',
+        selector: 'a[href*="/security/secret-scanning"]',
+        title: { ja: 'シークレットスキャン' },
+        description: {
+            ja: 'コミットに含まれる認証情報（APIキー、トークン）を検出。漏洩を防止します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-dependabot-alerts',
+        selector: 'a[href*="/security/dependabot/alerts"]',
+        title: { ja: 'Dependabotアラート' },
+        description: {
+            ja: '依存パッケージのセキュリティ脆弱性に関する警告。修正版へのアップデートを推奨します。',
+        },
+    },
+    // 使用量
+    {
+        type: 'hover',
+        id: 'hover-actions-usage',
+        selector: 'a[href*="/settings/billing"]',
+        title: { ja: '使用量' },
+        description: {
+            ja: 'GitHub Actionsの使用時間とストレージ。プランに応じた無料枠と超過分の請求を確認できます。',
+        },
+    },
+    // ワークフローファイル
+    {
+        type: 'hover',
+        id: 'hover-actions-workflow-file',
+        selector: 'a[href*="/.github/workflows/"]',
+        title: { ja: 'ワークフローファイル' },
+        description: {
+            ja: 'ワークフローを定義するYAMLファイル。.github/workflows/フォルダに配置します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-actions-marketplace',
+        selector: 'a[href*="/marketplace/actions"]',
+        title: { ja: 'Actionsマーケットプレイス' },
+        description: {
+            ja: 'コミュニティが作成した再利用可能なアクション。checkout、setup-node等を検索・利用できます。',
+        },
+    },
+    // アノテーション
+    {
+        type: 'hover',
+        id: 'hover-actions-annotations',
+        selector: '.js-workflow-annotations, [data-testid="annotations"]',
+        title: { ja: 'アノテーション' },
+        description: {
+            ja: 'ワークフロー実行中に発生した警告やエラー。問題のあるコード行を直接示します。',
+        },
+    },
 ];

--- a/src/dictionary/entries/branches.ts
+++ b/src/dictionary/entries/branches.ts
@@ -241,4 +241,264 @@ export const branchEntries: DictionaryEntry[] = [
             ja: 'プルリクエストやコードプッシュの既定の対象となるブランチ。通常は main または master です。',
         },
     },
+    // ブランチ一覧・管理
+    {
+        type: 'hover',
+        id: 'hover-branch-overview',
+        selector: '.Box-row .branch-name, [data-testid="branch-name"]',
+        title: { ja: 'ブランチ名' },
+        description: {
+            ja: 'ブランチの識別名。クリックするとそのブランチのコードを閲覧できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-branch-active',
+        selector: '.branch-type-active, [data-tab="active"]',
+        title: { ja: 'アクティブ' },
+        description: {
+            ja: '最近コミットがあったブランチ。活発に開発中のブランチです。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-branch-stale',
+        selector: '.branch-type-stale, [data-tab="stale"]',
+        title: { ja: '古いブランチ' },
+        description: {
+            ja: '3ヶ月以上更新がないブランチ。不要であれば削除を検討してください。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-branch-all',
+        selector: '[data-tab="all"]',
+        title: { ja: 'すべてのブランチ' },
+        description: {
+            ja: 'リポジトリ内のすべてのブランチを一覧表示します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-branch-yours',
+        selector: '[data-tab="yours"]',
+        title: { ja: 'あなたのブランチ' },
+        description: {
+            ja: 'あなたが作成したブランチのみを表示します。',
+        },
+    },
+    // ブランチ操作
+    {
+        type: 'hover',
+        id: 'hover-branch-create',
+        selector: 'button[data-hydro-click*="create_branch"], .js-new-branch-button',
+        title: { ja: 'ブランチを作成' },
+        description: {
+            ja: '新しいブランチを作成。現在のブランチの状態から分岐した開発ラインを作成します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-branch-delete',
+        selector: '.js-branch-delete-button, [aria-label*="Delete branch"]',
+        title: { ja: 'ブランチを削除' },
+        description: {
+            ja: '不要なブランチを削除。マージ済みのブランチは削除しても問題ありません。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-branch-restore',
+        selector: '.js-branch-restore, [aria-label*="Restore"]',
+        title: { ja: '復元' },
+        description: {
+            ja: '削除したブランチを復元します。削除後しばらくの間は復元可能です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-branch-rename',
+        selector: '[aria-label*="Rename branch"]',
+        title: { ja: 'ブランチ名を変更' },
+        description: {
+            ja: 'ブランチの名前を変更します。参照しているプルリクエストは自動更新されます。',
+        },
+    },
+    // ブランチ保護
+    {
+        type: 'hover',
+        id: 'hover-branch-protection',
+        selector: 'a[href*="/settings/branch_protection"], .js-protected-branches',
+        title: { ja: 'ブランチ保護' },
+        description: {
+            ja: 'ブランチに保護ルールを設定。強制プッシュの禁止やレビュー必須などを設定できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-branch-protection-rule',
+        selector: '.branch-protection-rule, [data-testid="branch-rule"]',
+        title: { ja: '保護ルール' },
+        description: {
+            ja: 'ブランチに適用される保護ルール。パターンマッチでブランチを指定できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-require-status-check',
+        selector: '[name="required_status_checks"]',
+        title: { ja: 'ステータスチェック必須' },
+        description: {
+            ja: 'マージ前にCIテストやチェックの成功を要求します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-require-review',
+        selector: '[name="required_pull_request_reviews"]',
+        title: { ja: 'レビュー必須' },
+        description: {
+            ja: 'マージ前にプルリクエストのレビュー承認を要求します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-require-signed-commits',
+        selector: '[name="required_signatures"]',
+        title: { ja: '署名付きコミット必須' },
+        description: {
+            ja: 'GPGまたはSSHで署名されたコミットのみを受け入れます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-dismiss-stale-reviews',
+        selector: '[name="dismiss_stale_reviews"]',
+        title: { ja: '古いレビューを無効化' },
+        description: {
+            ja: '新しいコミットがプッシュされると、既存のレビュー承認を無効化します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-restrict-pushes',
+        selector: '[name="restrict_pushes"]',
+        title: { ja: 'プッシュ制限' },
+        description: {
+            ja: '特定のユーザーまたはチームのみがブランチにプッシュできます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-block-force-push',
+        selector: '[name="allow_force_pushes"]',
+        title: { ja: '強制プッシュを禁止' },
+        description: {
+            ja: '強制プッシュ（履歴の書き換え）を禁止し、コミット履歴を保護します。',
+        },
+    },
+    // ブランチ比較
+    {
+        type: 'hover',
+        id: 'hover-branch-compare',
+        selector: 'a[href*="/compare/"], .js-compare-branch',
+        title: { ja: 'ブランチを比較' },
+        description: {
+            ja: '2つのブランチ間の差分を比較。プルリクエスト作成前の確認に便利です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-branch-ahead-behind',
+        selector: '.ahead-behind, [data-testid="ahead-behind"]',
+        title: { ja: '先行・遅れ' },
+        description: {
+            ja: 'デフォルトブランチと比較して、何コミット先行/遅れているかを表示します。',
+        },
+    },
+    // ブランチスイッチャー
+    {
+        type: 'hover',
+        id: 'hover-branch-switcher',
+        selector: '.js-branch-select-menu, [data-hotkey="w"]',
+        title: { ja: 'ブランチ切替' },
+        description: {
+            ja: '表示するブランチやタグを切り替えます。ショートカット: W',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-branch-find',
+        selector: '.js-branch-filter-field, [placeholder*="branch"]',
+        title: { ja: 'ブランチを検索' },
+        description: {
+            ja: 'ブランチ名で検索してフィルタリングします。',
+        },
+    },
+    // タグ
+    {
+        type: 'hover',
+        id: 'hover-tags',
+        selector: 'a[href*="/tags"]',
+        title: { ja: 'タグ' },
+        description: {
+            ja: '特定のコミットに付けたラベル。リリースバージョンのマーキングに使用します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-create-tag',
+        selector: '.js-create-tag, [data-testid="create-tag"]',
+        title: { ja: 'タグを作成' },
+        description: {
+            ja: '新しいタグを作成。通常はバージョン番号（v1.0.0等）を付けます。',
+        },
+    },
+    // マージオプション
+    {
+        type: 'hover',
+        id: 'hover-merge-commit',
+        selector: '[value="merge"], [data-merge-method="merge"]',
+        title: { ja: 'マージコミット' },
+        description: {
+            ja: 'すべてのコミットを保持し、マージコミットを作成。履歴が完全に保存されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-squash-merge',
+        selector: '[value="squash"], [data-merge-method="squash"]',
+        title: { ja: 'スカッシュマージ' },
+        description: {
+            ja: 'すべてのコミットを1つにまとめてマージ。履歴がシンプルになります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-rebase-merge',
+        selector: '[value="rebase"], [data-merge-method="rebase"]',
+        title: { ja: 'リベースマージ' },
+        description: {
+            ja: 'コミットを再適用してマージ。直線的な履歴になりますが、コミットハッシュが変わります。',
+        },
+    },
+    // コンフリクト
+    {
+        type: 'hover',
+        id: 'hover-conflict-warning',
+        selector: '.conflict-info, [data-testid="conflict-message"]',
+        title: { ja: 'コンフリクト' },
+        description: {
+            ja: '同じファイルの同じ箇所が別々に変更されました。手動での解決が必要です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-resolve-conflicts',
+        selector: '.js-resolve-conflicts, [aria-label*="Resolve conflicts"]',
+        title: { ja: 'コンフリクトを解決' },
+        description: {
+            ja: 'Webエディタでコンフリクトを解決。競合箇所を選択してマージを完了できます。',
+        },
+    },
 ];

--- a/src/dictionary/entries/git-operations.ts
+++ b/src/dictionary/entries/git-operations.ts
@@ -282,4 +282,209 @@ export const gitOperationsEntries: DictionaryEntry[] = [
             ja: 'ファイルの各行について、最後に変更したコミットと作者を表示します。いつ、誰が変更したかを追跡するのに便利です。',
         },
     },
+    // コミット関連
+    {
+        type: 'hover',
+        id: 'hover-git-commit-list',
+        selector: 'a[href*="/commits/"], .js-commits-list',
+        title: { ja: 'コミット履歴' },
+        description: {
+            ja: 'リポジトリのコミット履歴を時系列で表示。各コミットの内容、作者、日時を確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-commit-details',
+        selector: 'a[href*="/commit/"]',
+        title: { ja: 'コミット詳細' },
+        description: {
+            ja: 'コミットの詳細情報。変更されたファイル、追加・削除された行、コミットメッセージを表示します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-commit-sha',
+        selector: '.sha, .js-clipboard-copy[data-copy-text*="sha"]',
+        title: { ja: 'コミットSHA' },
+        description: {
+            ja: 'コミットを一意に識別する40文字のハッシュ値。7文字に短縮して表示されることが多いです。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-commit-verified',
+        selector: '.commit-signature-status, [data-testid="verified-badge"]',
+        title: { ja: '署名済み' },
+        description: {
+            ja: 'GPGまたはSSHキーで署名されたコミット。作者の身元が確認されています。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-browse-code',
+        selector: '.js-browse-at-commit, [aria-label*="Browse"]',
+        title: { ja: 'コードを閲覧' },
+        description: {
+            ja: 'このコミット時点でのリポジトリの状態を閲覧します。',
+        },
+    },
+    // クローン
+    {
+        type: 'hover',
+        id: 'hover-git-clone',
+        selector: '.js-clone-button, [data-testid="clone-button"]',
+        title: { ja: 'クローン' },
+        description: {
+            ja: 'リポジトリ全体をローカルにコピーします。履歴を含む完全なコピーが作成されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-clone-https',
+        selector: '[data-tab="https"]',
+        title: { ja: 'HTTPS' },
+        description: {
+            ja: 'HTTPSプロトコルでクローン。パスワードまたはPersonal Access Tokenで認証します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-clone-ssh',
+        selector: '[data-tab="ssh"]',
+        title: { ja: 'SSH' },
+        description: {
+            ja: 'SSHプロトコルでクローン。SSHキーを設定すると、プッシュ時にパスワード不要です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-clone-cli',
+        selector: '[data-tab="cli"]',
+        title: { ja: 'GitHub CLI' },
+        description: {
+            ja: 'GitHub CLIコマンドでクローン。ghコマンドがインストールされている必要があります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-download-zip',
+        selector: 'a[href*="/archive/"]',
+        title: { ja: 'ZIPでダウンロード' },
+        description: {
+            ja: 'リポジトリをZIPファイルとしてダウンロード。Git履歴は含まれません。',
+        },
+    },
+    // 差分・比較
+    {
+        type: 'hover',
+        id: 'hover-git-compare',
+        selector: 'a[href*="/compare/"]',
+        title: { ja: '比較' },
+        description: {
+            ja: '2つのブランチやコミット間の差分を表示。プルリクエスト作成前の確認に便利です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-diff-file',
+        selector: '.file-header, .js-diff-progressive-container',
+        title: { ja: 'ファイル差分' },
+        description: {
+            ja: 'ファイルの変更内容。緑が追加、赤が削除を示します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-diff-stats',
+        selector: '.diffstat, [data-testid="diffstat"]',
+        title: { ja: '差分統計' },
+        description: {
+            ja: '追加・削除された行数の統計。緑と赤のバーで変更量を視覚化します。',
+        },
+    },
+    // リバート・チェリーピック
+    {
+        type: 'hover',
+        id: 'hover-git-revert',
+        selector: '.js-revert-button, [data-testid="revert"]',
+        title: { ja: '元に戻す' },
+        description: {
+            ja: 'コミットの変更を打ち消す新しいコミットを作成。履歴を保持したまま変更を取り消します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-cherry-pick',
+        selector: '.js-cherry-pick, [data-testid="cherry-pick"]',
+        title: { ja: 'チェリーピック' },
+        description: {
+            ja: '特定のコミットを別のブランチに適用します。1つのコミットだけを取り込む場合に便利です。',
+        },
+    },
+    // 履歴表示
+    {
+        type: 'hover',
+        id: 'hover-git-history',
+        selector: 'a[data-analytics-event*="history"], [aria-label*="History"]',
+        title: { ja: '履歴' },
+        description: {
+            ja: 'ファイルの変更履歴。過去のバージョンを確認したり、特定のコミット時点のコードを見られます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-contributors',
+        selector: 'a[href*="/contributors"]',
+        title: { ja: '貢献者' },
+        description: {
+            ja: 'リポジトリにコミットしたユーザーの一覧。コミット数や追加・削除行数でランキング表示されます。',
+        },
+    },
+    // コミットグラフ
+    {
+        type: 'hover',
+        id: 'hover-git-network',
+        selector: 'a[href*="/network"]',
+        title: { ja: 'ネットワークグラフ' },
+        description: {
+            ja: 'ブランチとマージの履歴を視覚的に表示。フォーク間の関係も確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-insights-commits',
+        selector: 'a[href*="/graphs/commit-activity"]',
+        title: { ja: 'コミット活動' },
+        description: {
+            ja: '時間ごとのコミット数をグラフで表示。プロジェクトの活発さを確認できます。',
+        },
+    },
+    // ファイル操作
+    {
+        type: 'hover',
+        id: 'hover-git-raw',
+        selector: 'a[href*="/raw/"], [data-testid="raw-button"]',
+        title: { ja: 'Raw' },
+        description: {
+            ja: 'ファイルの生データを表示。スクリプトでのダウンロードやAPIアクセスに使用します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-copy-path',
+        selector: '.js-copy-path, [aria-label*="Copy path"]',
+        title: { ja: 'パスをコピー' },
+        description: {
+            ja: 'ファイルの相対パスをクリップボードにコピーします。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-git-permalink',
+        selector: '.js-permalink, [data-testid="permalink"]',
+        title: { ja: 'パーマリンク' },
+        description: {
+            ja: '特定のコミット時点へのリンク。このリンクは将来も同じ内容を指し続けます。',
+        },
+    },
 ];

--- a/src/dictionary/entries/issues.ts
+++ b/src/dictionary/entries/issues.ts
@@ -400,7 +400,8 @@ export const issueEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-issue-close-button',
-        selector: '.js-comment-and-button[value="close"], [data-testid="close-issue-button"]',
+        selector: '[data-testid="close-issue-button"], .js-comment-and-button[value="close"][formaction*="/issues/"]',
+        urlPattern: '/issues/',
         title: { ja: 'イシューをクローズ' },
         description: {
             ja: 'イシューを解決済みとしてクローズします。コメントを追加して理由を説明することもできます。',
@@ -409,7 +410,8 @@ export const issueEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-issue-reopen',
-        selector: '.js-comment-and-button[name="comment_and_open"]',
+        selector: '.js-comment-and-button[name="comment_and_open"][formaction*="/issues/"]',
+        urlPattern: '/issues/',
         title: { ja: 'イシューを再オープン' },
         description: {
             ja: 'クローズされたイシューを再度オープンします。追加の対応が必要な場合に使用します。',
@@ -428,7 +430,8 @@ export const issueEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-issue-linked-prs',
-        selector: '.js-issue-sidebar-form[data-linked-pr], .development-section',
+        selector: '.js-issue-sidebar-form[data-linked-pr]',
+        urlPattern: '/issues/',
         title: { ja: 'リンクされたPR' },
         description: {
             ja: 'このイシューを解決するプルリクエスト。PRがマージされるとイシューが自動的にクローズされます。',

--- a/src/dictionary/entries/issues.ts
+++ b/src/dictionary/entries/issues.ts
@@ -359,4 +359,261 @@ export const issueEntries: DictionaryEntry[] = [
             ja: 'イシューやプルリクエストの作業を担当するユーザー。複数人を割り当てることもできます。',
         },
     },
+    // 新規イシュー作成
+    {
+        type: 'hover',
+        id: 'hover-issue-new',
+        selector: 'a[href*="/issues/new"], .js-new-issue-button',
+        title: { ja: '新規イシュー' },
+        description: {
+            ja: '新しいイシューを作成します。バグ報告、機能リクエスト、質問などを記録できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-template',
+        selector: '.js-issue-template-select, a[href*="template="]',
+        title: { ja: 'イシューテンプレート' },
+        description: {
+            ja: '事前に定義されたイシューのフォーマット。バグ報告、機能リクエストなど用途別のテンプレートを選べます。',
+        },
+    },
+    // イシュー状態
+    {
+        type: 'hover',
+        id: 'hover-issue-open',
+        selector: '.State--open, [data-testid="state-open"]',
+        title: { ja: 'オープン' },
+        description: {
+            ja: 'まだ解決されていないイシュー。作業が進行中または未着手の状態です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-closed',
+        selector: '.State--closed, [data-testid="state-closed"]',
+        title: { ja: 'クローズ済み' },
+        description: {
+            ja: '解決または完了したイシュー。修正済み（紫）または対応しない（グレー）の理由で閉じられます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-close-button',
+        selector: '.js-comment-and-button[value="close"], [data-testid="close-issue-button"]',
+        title: { ja: 'イシューをクローズ' },
+        description: {
+            ja: 'イシューを解決済みとしてクローズします。コメントを追加して理由を説明することもできます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-reopen',
+        selector: '.js-comment-and-button[name="comment_and_open"]',
+        title: { ja: 'イシューを再オープン' },
+        description: {
+            ja: 'クローズされたイシューを再度オープンします。追加の対応が必要な場合に使用します。',
+        },
+    },
+    // プロジェクト連携
+    {
+        type: 'hover',
+        id: 'hover-issue-projects',
+        selector: '#projects-select-menu, .js-project-column-menu',
+        title: { ja: 'プロジェクト' },
+        description: {
+            ja: 'イシューをプロジェクトボードに追加します。カンバン形式でタスクの進捗を管理できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-linked-prs',
+        selector: '.js-issue-sidebar-form[data-linked-pr], .development-section',
+        title: { ja: 'リンクされたPR' },
+        description: {
+            ja: 'このイシューを解決するプルリクエスト。PRがマージされるとイシューが自動的にクローズされます。',
+        },
+    },
+    // リアクション
+    {
+        type: 'hover',
+        id: 'hover-issue-reactions',
+        selector: '.js-reaction-group-container, .comment-reactions',
+        title: { ja: 'リアクション' },
+        description: {
+            ja: 'イシューやコメントへの絵文字リアクション。👍で賛同、🎉で祝福、😕で困惑などを表現できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-add-reaction',
+        selector: '.js-add-reaction, [data-testid="add-reaction"]',
+        title: { ja: 'リアクションを追加' },
+        description: {
+            ja: '絵文字でリアクションを追加します。コメントを残さずに意見を表明する方法です。',
+        },
+    },
+    // タイムライン
+    {
+        type: 'hover',
+        id: 'hover-issue-timeline',
+        selector: '.js-discussion, .TimelineItem',
+        title: { ja: 'タイムライン' },
+        description: {
+            ja: 'イシューの履歴を時系列で表示。コメント、ラベル変更、担当者変更などすべてのアクティビティを確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-comment',
+        selector: '.js-comment, .timeline-comment',
+        title: { ja: 'コメント' },
+        description: {
+            ja: 'イシューへのコメント。Markdownが使え、@メンションで特定のユーザーに通知できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-cross-reference',
+        selector: '.discussion-item-ref, .TimelineItem--condensed',
+        title: { ja: '相互参照' },
+        description: {
+            ja: '他のイシューやPRからの参照。#123形式で別のイシューにリンクすると自動的に記録されます。',
+        },
+    },
+    // ロック・ピン
+    {
+        type: 'hover',
+        id: 'hover-issue-lock',
+        selector: '.js-lock-issue, [data-testid="lock-conversation"]',
+        title: { ja: 'イシューをロック' },
+        description: {
+            ja: 'コメントの追加を制限します。荒らし対策や議論の終了後に使用します。メンテナのみコメント可能になります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-pin',
+        selector: '.js-pin-issue, [data-testid="pin-issue"]',
+        title: { ja: 'イシューをピン' },
+        description: {
+            ja: 'イシューリストの上部に固定表示します。重要なお知らせやFAQを目立たせるのに使用します。',
+        },
+    },
+    // 転送
+    {
+        type: 'hover',
+        id: 'hover-issue-transfer',
+        selector: '.js-transfer-issue, [data-testid="transfer-issue"]',
+        title: { ja: 'イシューを転送' },
+        description: {
+            ja: 'イシューを別のリポジトリに移動します。間違ったリポジトリに作成された場合に使用します。',
+        },
+    },
+    // 検索・フィルタ
+    {
+        type: 'hover',
+        id: 'hover-issue-filter',
+        selector: '.js-issue-search, .subnav-search-input',
+        title: { ja: 'イシュー検索' },
+        description: {
+            ja: 'イシューをキーワードで検索します。is:open、label:bug、author:usernameなどの修飾子が使えます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-filter-open-closed',
+        selector: '.js-issue-state-toggle, [data-filter="open"], [data-filter="closed"]',
+        title: { ja: 'オープン/クローズフィルタ' },
+        description: {
+            ja: 'オープン中またはクローズ済みのイシューのみを表示します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-sort',
+        selector: '.js-issue-sort-select, [aria-label*="Sort"]',
+        title: { ja: 'ソート' },
+        description: {
+            ja: 'イシューの並び順を変更します。作成日、更新日、コメント数などで並べ替えられます。',
+        },
+    },
+    // 一括編集
+    {
+        type: 'hover',
+        id: 'hover-issue-bulk-edit',
+        selector: '.js-bulk-actions-menu, [data-testid="issue-bulk-actions"]',
+        title: { ja: '一括編集' },
+        description: {
+            ja: '選択した複数のイシューをまとめて編集します。ラベル追加、クローズ、マイルストーン設定などが一括でできます。',
+        },
+    },
+    // 開発者向け
+    {
+        type: 'hover',
+        id: 'hover-issue-development',
+        selector: '.development-section-header, [data-testid="development-section"]',
+        title: { ja: '開発' },
+        description: {
+            ja: 'このイシューに関連するブランチやPRを管理します。新しいブランチを作成してすぐに作業を開始できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-create-branch',
+        selector: '.js-create-branch-from-issue, [data-testid="create-branch"]',
+        title: { ja: 'ブランチを作成' },
+        description: {
+            ja: 'このイシュー用の新しいブランチを作成します。ブランチ名は自動的にイシュー番号を含みます。',
+        },
+    },
+    // 通知
+    {
+        type: 'hover',
+        id: 'hover-issue-subscribe',
+        selector: '.js-subscribe-button, [data-testid="subscribe-button"]',
+        title: { ja: '通知を購読' },
+        description: {
+            ja: 'このイシューの更新通知を受け取ります。コメント、状態変更、ラベル変更などが通知されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-issue-unsubscribe',
+        selector: '.js-unsubscribe-button, [data-testid="unsubscribe-button"]',
+        title: { ja: '通知を解除' },
+        description: {
+            ja: 'このイシューの更新通知を停止します。',
+        },
+    },
+    // 参加者
+    {
+        type: 'hover',
+        id: 'hover-issue-participants',
+        selector: '.participation, [data-testid="participants"]',
+        title: { ja: '参加者' },
+        description: {
+            ja: 'このイシューにコメントやアクションした全ユーザーの一覧。',
+        },
+    },
+    // マークダウン
+    {
+        type: 'hover',
+        id: 'hover-issue-task-list',
+        selector: '.task-list, .contains-task-list',
+        title: { ja: 'タスクリスト' },
+        description: {
+            ja: 'チェックボックス付きのタスクリスト。- [ ]で未完了、- [x]で完了。進捗がイシュー一覧に表示されます。',
+        },
+    },
+    // サイドバー
+    {
+        type: 'hover',
+        id: 'hover-issue-sidebar',
+        selector: '.Layout-sidebar .discussion-sidebar, [data-testid="issue-sidebar"]',
+        title: { ja: 'サイドバー' },
+        description: {
+            ja: 'イシューのメタデータを管理するパネル。担当者、ラベル、マイルストーン、プロジェクトなどを設定できます。',
+        },
+    },
 ];

--- a/src/dictionary/entries/issues.ts
+++ b/src/dictionary/entries/issues.ts
@@ -442,6 +442,7 @@ export const issueEntries: DictionaryEntry[] = [
         type: 'hover',
         id: 'hover-issue-reactions',
         selector: '.js-reaction-group-container, .comment-reactions',
+        urlPattern: '/issues/',
         title: { ja: 'リアクション' },
         description: {
             ja: 'イシューやコメントへの絵文字リアクション。👍で賛同、🎉で祝福、😕で困惑などを表現できます。',

--- a/src/dictionary/entries/navigation.ts
+++ b/src/dictionary/entries/navigation.ts
@@ -500,58 +500,311 @@ export const navigationEntries: DictionaryEntry[] = [
     },
 
     // === Hover Entries ===
+    // リポジトリタブナビゲーション
     {
         type: 'hover',
         id: 'hover-nav-code',
-        selector: 'nav[aria-label="Repository"] a[data-tab-item="i2code-tab"]',
+        selector: 'nav[aria-label="Repository"] a[data-tab-item="i2code-tab"], a#code-tab',
         title: { ja: 'コード' },
         description: {
-            ja: 'リポジトリのソースコードとファイルを閲覧できます。ブランチやタグの切り替えも可能です。',
+            ja: 'リポジトリのソースコードとファイルを閲覧できます。ブランチやタグの切り替え、ファイルのダウンロードも可能です。',
         },
     },
     {
         type: 'hover',
         id: 'hover-nav-wiki',
-        selector: 'nav a[href*="/wiki"]',
+        selector: 'nav a[href*="/wiki"], a#wiki-tab',
         title: { ja: 'Wiki' },
         description: {
-            ja: 'プロジェクトのドキュメントを共同で作成・編集できるスペース。マークダウン形式で記述します。',
+            ja: 'プロジェクトのドキュメントを共同で作成・編集できるスペース。マークダウン形式で記述し、複数ページを階層化できます。',
         },
     },
     {
         type: 'hover',
         id: 'hover-nav-security',
-        selector: 'nav a[href*="/security"]',
+        selector: 'nav a[href*="/security"], a#security-tab',
         title: { ja: 'セキュリティ' },
         description: {
-            ja: 'セキュリティポリシー、依存関係の脆弱性アラート、シークレットスキャンなどを管理します。',
+            ja: 'セキュリティポリシー、依存関係の脆弱性アラート、シークレットスキャン、コードスキャンなどを管理します。',
         },
     },
     {
         type: 'hover',
         id: 'hover-nav-insights',
-        selector: 'nav a[href*="/pulse"], nav a[href*="/graphs"]',
+        selector: 'nav a[href*="/pulse"], nav a[href*="/graphs"], a#insights-tab',
         title: { ja: 'インサイト' },
         description: {
-            ja: 'リポジトリの活動状況、コントリビューター統計、コード頻度などの分析データを表示します。',
+            ja: 'リポジトリの活動状況、コントリビューター統計、コード頻度、依存関係グラフなどの分析データを表示します。',
         },
     },
     {
         type: 'hover',
         id: 'hover-nav-settings',
-        selector: 'nav a[href*="/settings"]',
+        selector: 'nav a[href*="/settings"], a#settings-tab',
         title: { ja: '設定' },
         description: {
-            ja: 'リポジトリの設定を管理します。ブランチ保護、Webhook、アクセス権限などを設定できます。',
+            ja: 'リポジトリの設定を管理。ブランチ保護ルール、Webhook、GitHub Apps、デプロイキー、アクセス権限などを設定できます。',
         },
     },
     {
         type: 'hover',
         id: 'hover-nav-discussions',
-        selector: 'nav a[href*="/discussions"]',
+        selector: 'nav a[href*="/discussions"], a#discussions-tab',
         title: { ja: 'ディスカッション' },
         description: {
-            ja: 'コミュニティとの対話スペース。Q&A、アイデア共有、お知らせなど、イシュー以外の会話に使います。',
+            ja: 'コミュニティとの対話スペース。Q&A、アイデア共有、お知らせなど、イシュー以外の会話に使います。投票機能もあります。',
+        },
+    },
+
+    // ヘッダーナビゲーション
+    {
+        type: 'hover',
+        id: 'hover-nav-search',
+        selector: 'button[data-target="qbsearch-input.inputButton"], input[name="q"], .header-search-wrapper',
+        title: { ja: '検索バー' },
+        description: {
+            ja: 'GitHub全体またはリポジトリ内を検索。コード、イシュー、PR、ユーザー、リポジトリを高度なフィルタで検索できます。「/」キーでフォーカス。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-notifications',
+        selector: 'a[href="/notifications"], notification-indicator',
+        title: { ja: '通知' },
+        description: {
+            ja: 'あなた宛ての通知一覧。メンション、レビュー依頼、Watch中のリポジトリの更新などが表示されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-create-new',
+        selector: 'details[data-target*="create-menu"], .Header-link[href="/new"]',
+        title: { ja: '新規作成メニュー' },
+        description: {
+            ja: '新しいリポジトリ、Gist、組織、プロジェクトなどを作成するメニュー。インポートも可能です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-user-menu',
+        selector: 'details[data-target*="header-user"], summary.Header-link img.avatar',
+        title: { ja: 'ユーザーメニュー' },
+        description: {
+            ja: 'プロフィール、リポジトリ、スター、設定、サインアウトなどへのショートカット。テーマ切替やステータス設定もここから。',
+        },
+    },
+
+    // ファイルブラウザ関連
+    {
+        type: 'hover',
+        id: 'hover-nav-go-to-file',
+        selector: 'a[data-hotkey="t"], button:has-text("Go to file")',
+        title: { ja: 'ファイルへ移動' },
+        description: {
+            ja: 'ファインダーを開いてファイル名で検索し、素早く移動できます。キーボードショートカット「t」でも起動可能。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-add-file',
+        selector: 'details summary:has-text("Add file"), [data-target="get-repo.addFileSummary"]',
+        title: { ja: 'ファイル追加' },
+        description: {
+            ja: '新しいファイルをブラウザ上で作成するか、ローカルからアップロードできます。コミットメッセージも指定可能。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-code-button',
+        selector: 'button[id*="code-dropdown"], summary[data-target="get-repo.showCloneMenuSummary"], get-repo summary.btn',
+        title: { ja: 'Code ボタン' },
+        description: {
+            ja: 'リポジトリのクローンURL（HTTPS/SSH/CLI）を取得。GitHub Desktop/Codespacesで開く、ZIPダウンロードも可能です。',
+        },
+    },
+
+    // ファイル操作ボタン
+    {
+        type: 'hover',
+        id: 'hover-nav-raw-button',
+        selector: 'a[data-view-component="true"][href*="/raw/"], a.btn:has-text("Raw")',
+        title: { ja: 'Raw' },
+        description: {
+            ja: 'ファイルの生データを表示。フォーマットなしのテキストとして取得でき、直接ダウンロードも可能です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-blame-button',
+        selector: 'a[data-view-component="true"][href*="/blame/"], a.btn:has-text("Blame")',
+        title: { ja: 'Blame' },
+        description: {
+            ja: '各行を最後に変更したコミットと作者を表示。誰がいつ何のために変更したかを追跡できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-history-button',
+        selector: 'a[href*="/commits/"], a.btn:has-text("History")',
+        title: { ja: '履歴' },
+        description: {
+            ja: 'このファイルの変更履歴（コミット一覧）を表示。過去のバージョンを確認・比較できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-edit-button',
+        selector: 'a[aria-label="Edit this file"], button[aria-label*="Edit"]',
+        title: { ja: 'ファイル編集' },
+        description: {
+            ja: 'ブラウザ上でファイルを直接編集。変更後、新しいコミットまたはPRとして保存できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-delete-button',
+        selector: 'button[aria-label="Delete this file"], a[aria-label*="Delete"]',
+        title: { ja: 'ファイル削除' },
+        description: {
+            ja: 'このファイルを削除するコミットを作成。削除理由をコミットメッセージに記載できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-copy-path',
+        selector: 'clipboard-copy[aria-label*="Copy path"], button[aria-label*="Copy path"]',
+        title: { ja: 'パスをコピー' },
+        description: {
+            ja: 'ファイルの相対パスをクリップボードにコピー。README等でリンクを作成する際に便利です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-copy-permalink',
+        selector: 'clipboard-copy[aria-label*="Copy permalink"], button[aria-label*="permalink"]',
+        title: { ja: 'パーマリンクをコピー' },
+        description: {
+            ja: '特定のコミット時点でのファイルへの永続リンクをコピー。将来ファイルが変わっても同じ内容を参照できます。',
+        },
+    },
+
+    // ブランチ・タグセレクタ
+    {
+        type: 'hover',
+        id: 'hover-nav-branch-selector',
+        selector: 'summary[data-hotkey="w"], ref-selector, button[id*="branch-selector"]',
+        title: { ja: 'ブランチ/タグ切替' },
+        description: {
+            ja: '表示するブランチやタグを切り替えます。新しいブランチの作成もここから可能。ショートカット「w」。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-compare-pr',
+        selector: 'a[href*="/compare/"], a.btn:has-text("Compare")',
+        title: { ja: 'Compare & Pull request' },
+        description: {
+            ja: 'ブランチ間の差分を比較し、プルリクエストを作成します。最近プッシュしたブランチがある場合に表示されます。',
+        },
+    },
+
+    // パンくずリスト
+    {
+        type: 'hover',
+        id: 'hover-nav-breadcrumb',
+        selector: 'nav[aria-label="Breadcrumb"] a, .js-path-segment',
+        title: { ja: 'パンくずリスト' },
+        description: {
+            ja: '現在のファイル/フォルダの階層構造を表示。クリックで上位ディレクトリへ移動できます。',
+        },
+    },
+
+    // フッター・About
+    {
+        type: 'hover',
+        id: 'hover-nav-about-edit',
+        selector: 'button[aria-label="Edit repository metadata"], a[href*="/settings"]:has-text("Edit")',
+        title: { ja: 'リポジトリ情報編集' },
+        description: {
+            ja: 'リポジトリの説明文、ウェブサイトURL、トピックを編集します。検索性向上のためトピック設定を推奨。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-readme',
+        selector: 'article.markdown-body, .readme, #readme',
+        title: { ja: 'README' },
+        description: {
+            ja: 'プロジェクトの概要、使い方、インストール方法などを説明するドキュメント。最初に読むべきファイルです。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-license',
+        selector: 'a[href*="/blob/"][href*="LICENSE"], a.Link--muted[href*="license"]',
+        title: { ja: 'ライセンス' },
+        description: {
+            ja: 'このリポジトリのコードのライセンス条件。商用利用、改変、再配布の可否などが定義されています。',
+        },
+    },
+
+    // Explore・ダッシュボード
+    {
+        type: 'hover',
+        id: 'hover-nav-explore',
+        selector: 'a[href="/explore"], a:has-text("Explore")',
+        title: { ja: 'Explore' },
+        description: {
+            ja: 'トレンドリポジトリ、トピック、コレクション、開発者を発見。新しいプロジェクトやツールを見つけられます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-marketplace',
+        selector: 'a[href="/marketplace"], a:has-text("Marketplace")',
+        title: { ja: 'Marketplace' },
+        description: {
+            ja: 'GitHub Actions、GitHub Appsなどの拡張機能を検索・インストール。CI/CD、コードレビューツールなど多数。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-trending',
+        selector: 'a[href="/trending"], a:has-text("Trending")',
+        title: { ja: 'トレンド' },
+        description: {
+            ja: '今日/今週/今月で人気上昇中のリポジトリ一覧。言語やトピックでフィルタ可能です。',
+        },
+    },
+
+    // フィルタ・ソート
+    {
+        type: 'hover',
+        id: 'hover-nav-filter-menu',
+        selector: 'details-menu[src*="filter"], .subnav-search-context, button:has-text("Filters")',
+        title: { ja: 'フィルター' },
+        description: {
+            ja: '一覧を条件で絞り込み。著者、ラベル、マイルストーン、レビュー状況などで検索結果を限定できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-nav-sort-menu',
+        selector: 'details-menu[src*="sort"], select[name="sort"], button:has-text("Sort")',
+        title: { ja: '並び替え' },
+        description: {
+            ja: '一覧の並び順を変更。作成日、更新日、コメント数、リアクション数などで並べ替えられます。',
+        },
+    },
+
+    // ページネーション
+    {
+        type: 'hover',
+        id: 'hover-nav-pagination',
+        selector: '.pagination a, [aria-label="Pagination"]',
+        title: { ja: 'ページネーション' },
+        description: {
+            ja: '結果が複数ページにわたる場合のページ切り替え。「Previous」「Next」または番号をクリック。',
         },
     },
 ];

--- a/src/dictionary/entries/navigation.ts
+++ b/src/dictionary/entries/navigation.ts
@@ -598,7 +598,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-go-to-file',
-        selector: 'a[data-hotkey="t"], button:has-text("Go to file")',
+        selector: 'a[data-hotkey="t"], button[aria-label*="file" i], button[data-testid="go-to-file-button"]',
         title: { ja: 'ファイルへ移動' },
         description: {
             ja: 'ファインダーを開いてファイル名で検索し、素早く移動できます。キーボードショートカット「t」でも起動可能。',
@@ -607,7 +607,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-add-file',
-        selector: 'details summary:has-text("Add file"), [data-target="get-repo.addFileSummary"]',
+        selector: 'details summary[aria-label*="Add file" i], [data-target="get-repo.addFileSummary"]',
         title: { ja: 'ファイル追加' },
         description: {
             ja: '新しいファイルをブラウザ上で作成するか、ローカルからアップロードできます。コミットメッセージも指定可能。',
@@ -627,7 +627,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-raw-button',
-        selector: 'a[data-view-component="true"][href*="/raw/"], a.btn:has-text("Raw")',
+        selector: 'a[data-view-component="true"][href*="/raw/"], a[href*="/raw/"]',
         title: { ja: 'Raw' },
         description: {
             ja: 'ファイルの生データを表示。フォーマットなしのテキストとして取得でき、直接ダウンロードも可能です。',
@@ -636,7 +636,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-blame-button',
-        selector: 'a[data-view-component="true"][href*="/blame/"], a.btn:has-text("Blame")',
+        selector: 'a[data-view-component="true"][href*="/blame/"], a[href*="/blame/"]',
         title: { ja: 'Blame' },
         description: {
             ja: '各行を最後に変更したコミットと作者を表示。誰がいつ何のために変更したかを追跡できます。',
@@ -645,7 +645,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-history-button',
-        selector: 'a[href*="/commits/"], a.btn:has-text("History")',
+        selector: 'a[href*="/commits/"], a[aria-label*="History" i]',
         title: { ja: '履歴' },
         description: {
             ja: 'このファイルの変更履歴（コミット一覧）を表示。過去のバージョンを確認・比較できます。',
@@ -701,7 +701,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-compare-pr',
-        selector: 'a[href*="/compare/"], a.btn:has-text("Compare")',
+        selector: 'a[href*="/compare/"]',
         title: { ja: 'Compare & Pull request' },
         description: {
             ja: 'ブランチ間の差分を比較し、プルリクエストを作成します。最近プッシュしたブランチがある場合に表示されます。',
@@ -723,7 +723,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-about-edit',
-        selector: 'button[aria-label="Edit repository metadata"], a[href*="/settings"]:has-text("Edit")',
+        selector: 'button[aria-label="Edit repository metadata"], a[href*="/settings"][aria-label*="Edit" i]',
         title: { ja: 'リポジトリ情報編集' },
         description: {
             ja: 'リポジトリの説明文、ウェブサイトURL、トピックを編集します。検索性向上のためトピック設定を推奨。',
@@ -752,7 +752,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-explore',
-        selector: 'a[href="/explore"], a:has-text("Explore")',
+        selector: 'a[href="/explore"]',
         title: { ja: 'Explore' },
         description: {
             ja: 'トレンドリポジトリ、トピック、コレクション、開発者を発見。新しいプロジェクトやツールを見つけられます。',
@@ -761,7 +761,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-marketplace',
-        selector: 'a[href="/marketplace"], a:has-text("Marketplace")',
+        selector: 'a[href="/marketplace"]',
         title: { ja: 'Marketplace' },
         description: {
             ja: 'GitHub Actions、GitHub Appsなどの拡張機能を検索・インストール。CI/CD、コードレビューツールなど多数。',
@@ -770,7 +770,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-trending',
-        selector: 'a[href="/trending"], a:has-text("Trending")',
+        selector: 'a[href="/trending"]',
         title: { ja: 'トレンド' },
         description: {
             ja: '今日/今週/今月で人気上昇中のリポジトリ一覧。言語やトピックでフィルタ可能です。',
@@ -781,7 +781,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-filter-menu',
-        selector: 'details-menu[src*="filter"], .subnav-search-context, button:has-text("Filters")',
+        selector: 'details-menu[src*="filter"], .subnav-search-context, button[aria-label*="Filter" i]',
         title: { ja: 'フィルター' },
         description: {
             ja: '一覧を条件で絞り込み。著者、ラベル、マイルストーン、レビュー状況などで検索結果を限定できます。',
@@ -790,7 +790,7 @@ export const navigationEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-nav-sort-menu',
-        selector: 'details-menu[src*="sort"], select[name="sort"], button:has-text("Sort")',
+        selector: 'details-menu[src*="sort"], select[name="sort"], button[aria-label*="Sort" i]',
         title: { ja: '並び替え' },
         description: {
             ja: '一覧の並び順を変更。作成日、更新日、コメント数、リアクション数などで並べ替えられます。',

--- a/src/dictionary/entries/pull-requests.ts
+++ b/src/dictionary/entries/pull-requests.ts
@@ -342,7 +342,8 @@ export const pullRequestEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-pr-conversation-tab',
-        selector: 'a[href*="/pull/"][href$=""], [data-tab-item="conversation-tab"]',
+        selector: '#conversation-tab, [data-tab-item="conversation-tab"]',
+        urlPattern: '/pull/',
         title: { ja: 'Conversationタブ' },
         description: {
             ja: 'PRの概要、説明、コメントのやり取りを表示。タイムラインでレビューやコミットの履歴を確認できます。',
@@ -564,7 +565,8 @@ export const pullRequestEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-pr-close',
-        selector: '.js-comment-and-button[value="close"], [data-testid="close-button"]',
+        selector: '[data-testid="close-pull-request-button"], .js-comment-and-button[value="close"][formaction*="/pull/"]',
+        urlPattern: '/pull/',
         title: { ja: 'PRをクローズ' },
         description: {
             ja: 'PRをマージせずに閉じます。変更が不要になった場合や、別のPRで対応する場合に使用します。',
@@ -573,7 +575,8 @@ export const pullRequestEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-pr-reopen',
-        selector: '.js-comment-and-button[name="comment_and_open"]',
+        selector: '.js-comment-and-button[name="comment_and_open"][formaction*="/pull/"]',
+        urlPattern: '/pull/',
         title: { ja: 'PRを再オープン' },
         description: {
             ja: 'クローズされたPRを再度オープンします。追加の作業が必要になった場合に使用します。',
@@ -600,7 +603,8 @@ export const pullRequestEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-pr-linked-issues',
-        selector: '.js-issue-sidebar-form[data-linked-issue], .development-section',
+        selector: '.js-issue-sidebar-form[data-linked-issue]',
+        urlPattern: '/pull/',
         title: { ja: 'リンクされたイシュー' },
         description: {
             ja: 'このPRがクローズするイシュー。「Fixes #123」のようにコミットやPR説明に書くと自動でリンクされます。',

--- a/src/dictionary/entries/pull-requests.ts
+++ b/src/dictionary/entries/pull-requests.ts
@@ -338,4 +338,290 @@ export const pullRequestEntries: DictionaryEntry[] = [
             ja: '作業中のプルリクエストを示します。ドラフト状態ではマージできず、準備完了になるまでレビューは任意です。',
         },
     },
+    // PRタブナビゲーション
+    {
+        type: 'hover',
+        id: 'hover-pr-conversation-tab',
+        selector: 'a[href*="/pull/"][href$=""], [data-tab-item="conversation-tab"]',
+        title: { ja: 'Conversationタブ' },
+        description: {
+            ja: 'PRの概要、説明、コメントのやり取りを表示。タイムラインでレビューやコミットの履歴を確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-commits-tab',
+        selector: 'a[href*="/commits"], [data-tab-item="commits-tab"]',
+        title: { ja: 'Commitsタブ' },
+        description: {
+            ja: 'このPRに含まれるすべてのコミットを一覧表示。各コミットの詳細や差分を確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-checks-tab',
+        selector: 'a[href*="/checks"], [data-tab-item="checks-tab"]',
+        title: { ja: 'Checksタブ' },
+        description: {
+            ja: 'CI/CDパイプラインの実行結果を表示。テスト、リント、ビルドなどの自動チェックの状態を確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-files-changed-tab',
+        selector: 'a[href*="/files"], [data-tab-item="files-changed-tab"]',
+        title: { ja: 'Files changedタブ' },
+        description: {
+            ja: '変更されたファイルの差分を表示。追加（緑）、削除（赤）がハイライトされ、行ごとにコメントを残せます。',
+        },
+    },
+    // Diff関連
+    {
+        type: 'hover',
+        id: 'hover-pr-diff-view',
+        selector: '.diff-view, .file-diff, [data-diff-anchor]',
+        title: { ja: '差分ビュー' },
+        description: {
+            ja: 'ファイルの変更内容を表示。Unified（統合）とSplit（分割）の2つの表示モードがあります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-diff-unified',
+        selector: '[data-action="unified"], .js-diff-style-toggle[data-value="unified"]',
+        title: { ja: 'Unified表示' },
+        description: {
+            ja: '変更前後を1つのビューに統合表示。追加行と削除行が上下に並んで表示されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-diff-split',
+        selector: '[data-action="split"], .js-diff-style-toggle[data-value="split"]',
+        title: { ja: 'Split表示' },
+        description: {
+            ja: '変更前（左）と変更後（右）を左右に並べて表示。大きな変更の比較に便利です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-file-tree',
+        selector: '.js-diff-progressive-container, .file-tree',
+        title: { ja: 'ファイルツリー' },
+        description: {
+            ja: '変更されたファイルをツリー構造で表示。フォルダを展開/折りたたみして特定のファイルに素早くジャンプできます。',
+        },
+    },
+    // レビュー関連
+    {
+        type: 'hover',
+        id: 'hover-pr-add-review',
+        selector: '.js-reviews-container [role="button"], .review-summary-button',
+        title: { ja: 'レビューを追加' },
+        description: {
+            ja: 'ファイルの変更に対してレビューを開始。コメント、承認、変更リクエストを選んで提出できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-review-comment',
+        selector: '.review-comment, .js-comment, [data-testid="review-comment"]',
+        title: { ja: 'レビューコメント' },
+        description: {
+            ja: '特定の行やコードブロックに対するフィードバック。質問、提案、修正依頼などを記録できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-suggestion',
+        selector: '.js-suggestion-button, .suggestion-blob',
+        title: { ja: '提案（Suggestion）' },
+        description: {
+            ja: 'コードの変更を直接提案する機能。提案されたコードをワンクリックで適用できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-start-review',
+        selector: 'button[name="single_comment"], .js-start-review',
+        title: { ja: 'レビューを開始' },
+        description: {
+            ja: '複数のコメントをまとめてレビューとして提出。個別コメントではなくバッチでフィードバックを送れます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-pending-review',
+        selector: '.js-pending-review-count, [data-pending-review]',
+        title: { ja: '保留中のレビュー' },
+        description: {
+            ja: 'まだ提出されていないレビューコメント。「Submit review」で一括送信できます。',
+        },
+    },
+    // マージ関連
+    {
+        type: 'hover',
+        id: 'hover-pr-merge-button',
+        selector: '.merge-box-button, [data-testid="merge-button"], .js-merge-box-button',
+        title: { ja: 'マージボタン' },
+        description: {
+            ja: 'PRの変更をベースブランチに統合します。すべてのチェックが通過し、必要な承認があれば有効になります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-squash-merge',
+        selector: '[data-details-container=".js-merge-pr"] [value="squash"]',
+        title: { ja: 'スカッシュ＆マージ' },
+        description: {
+            ja: 'すべてのコミットを1つにまとめてマージ。履歴がコンパクトになり、クリーンなコミットログを維持できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-rebase-merge',
+        selector: '[data-details-container=".js-merge-pr"] [value="rebase"]',
+        title: { ja: 'リベース＆マージ' },
+        description: {
+            ja: '各コミットをベースブランチの先頭に再適用。マージコミットなしで直線的な履歴を作成します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-auto-merge',
+        selector: '.js-auto-merge-box, [data-testid="enable-auto-merge"]',
+        title: { ja: '自動マージ' },
+        description: {
+            ja: '必要な条件（レビュー承認、CIパス）が満たされたら自動的にマージ。手動での待機が不要になります。',
+        },
+    },
+    // CIステータス関連
+    {
+        type: 'hover',
+        id: 'hover-pr-ci-status',
+        selector: '.branch-action-item .merge-status-list, .status-heading',
+        title: { ja: 'CIステータス' },
+        description: {
+            ja: '継続的インテグレーション（CI）の結果。テスト、ビルド、リントなどの自動チェックの成否を表示します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-status-check-passed',
+        selector: '.octicon-check.color-fg-success, .status-success',
+        title: { ja: 'チェック成功' },
+        description: {
+            ja: '自動チェックが正常に完了しました。すべてのテストやビルドが成功しています。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-status-check-failed',
+        selector: '.octicon-x.color-fg-danger, .status-failure',
+        title: { ja: 'チェック失敗' },
+        description: {
+            ja: '自動チェックに失敗しました。詳細を確認して問題を修正する必要があります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-status-pending',
+        selector: '.octicon-dot-fill.color-fg-attention, .status-pending',
+        title: { ja: 'チェック実行中' },
+        description: {
+            ja: '自動チェックが実行中です。完了まで待つか、詳細でログを確認できます。',
+        },
+    },
+    // コンフリクト
+    {
+        type: 'hover',
+        id: 'hover-pr-conflicts',
+        selector: '.merge-conflicts, .js-merge-conflict-message',
+        title: { ja: 'コンフリクト' },
+        description: {
+            ja: 'ベースブランチと競合する変更があります。マージ前に手動で解決する必要があります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-resolve-conflicts',
+        selector: '.js-resolve-conflicts-button, a[href*="conflicts"]',
+        title: { ja: 'コンフリクトを解決' },
+        description: {
+            ja: 'Web上またはローカルでコンフリクトを解決できます。どちらの変更を残すか選択します。',
+        },
+    },
+    // その他
+    {
+        type: 'hover',
+        id: 'hover-pr-update-branch',
+        selector: '.js-update-branch-form, [data-testid="update-branch-button"]',
+        title: { ja: 'ブランチを更新' },
+        description: {
+            ja: 'ベースブランチの最新変更をPRブランチに取り込みます。コンフリクト防止や最新コードでのテストに有効です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-close',
+        selector: '.js-comment-and-button[value="close"], [data-testid="close-button"]',
+        title: { ja: 'PRをクローズ' },
+        description: {
+            ja: 'PRをマージせずに閉じます。変更が不要になった場合や、別のPRで対応する場合に使用します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-reopen',
+        selector: '.js-comment-and-button[name="comment_and_open"]',
+        title: { ja: 'PRを再オープン' },
+        description: {
+            ja: 'クローズされたPRを再度オープンします。追加の作業が必要になった場合に使用します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-ready-for-review',
+        selector: '.js-ready-for-review-button, [data-testid="ready-for-review"]',
+        title: { ja: 'レビュー準備完了' },
+        description: {
+            ja: 'ドラフト状態を解除してレビュー可能にします。作業が完了し、フィードバックを受ける準備が整った時に使用します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-convert-to-draft',
+        selector: '.js-convert-to-draft, [data-testid="convert-to-draft"]',
+        title: { ja: 'ドラフトに変換' },
+        description: {
+            ja: 'PRをドラフト状態に戻します。追加の作業が必要な場合や、まだレビューを受けたくない場合に使用します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-linked-issues',
+        selector: '.js-issue-sidebar-form[data-linked-issue], .development-section',
+        title: { ja: 'リンクされたイシュー' },
+        description: {
+            ja: 'このPRがクローズするイシュー。「Fixes #123」のようにコミットやPR説明に書くと自動でリンクされます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-delete-branch',
+        selector: '.js-delete-branch-button, [data-testid="delete-branch-button"]',
+        title: { ja: 'ブランチを削除' },
+        description: {
+            ja: 'マージ後にPRブランチを削除します。クリーンなブランチ管理のため、マージ後の削除が推奨されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pr-restore-branch',
+        selector: '.js-restore-branch-button, [data-testid="restore-branch-button"]',
+        title: { ja: 'ブランチを復元' },
+        description: {
+            ja: '削除されたブランチを復元します。誤って削除した場合や追加の作業が必要な場合に使用します。',
+        },
+    },
 ];

--- a/src/dictionary/entries/pull-requests.ts
+++ b/src/dictionary/entries/pull-requests.ts
@@ -323,7 +323,7 @@ export const pullRequestEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-pr-merge-options',
-        selector: '.merge-message .btn-group-merge, [data-testid="merge-box"] .btn-group-merge, [data-testid="pull-request-merge-box"] buttongroup',
+        selector: '.merge-message .btn-group-merge, [data-testid="merge-box"] .btn-group-merge',
         title: { ja: 'マージオプション' },
         description: {
             ja: 'マージ方法を選択できます。マージコミット（履歴を保持）、スカッシュ（1つのコミットに圧縮）、リベース（履歴を直線化）から選べます。',
@@ -353,6 +353,7 @@ export const pullRequestEntries: DictionaryEntry[] = [
         type: 'hover',
         id: 'hover-pr-commits-tab',
         selector: 'a[href*="/commits"], [data-tab-item="commits-tab"]',
+        urlPattern: '/pull/',
         title: { ja: 'Commitsタブ' },
         description: {
             ja: 'このPRに含まれるすべてのコミットを一覧表示。各コミットの詳細や差分を確認できます。',
@@ -362,6 +363,7 @@ export const pullRequestEntries: DictionaryEntry[] = [
         type: 'hover',
         id: 'hover-pr-checks-tab',
         selector: 'a[href*="/checks"], [data-tab-item="checks-tab"]',
+        urlPattern: '/pull/',
         title: { ja: 'Checksタブ' },
         description: {
             ja: 'CI/CDパイプラインの実行結果を表示。テスト、リント、ビルドなどの自動チェックの状態を確認できます。',
@@ -371,6 +373,7 @@ export const pullRequestEntries: DictionaryEntry[] = [
         type: 'hover',
         id: 'hover-pr-files-changed-tab',
         selector: 'a[href*="/files"], [data-tab-item="files-changed-tab"]',
+        urlPattern: '/pull/',
         title: { ja: 'Files changedタブ' },
         description: {
             ja: '変更されたファイルの差分を表示。追加（緑）、削除（赤）がハイライトされ、行ごとにコメントを残せます。',
@@ -427,6 +430,7 @@ export const pullRequestEntries: DictionaryEntry[] = [
         type: 'hover',
         id: 'hover-pr-review-comment',
         selector: '.review-comment, .js-comment, [data-testid="review-comment"]',
+        urlPattern: '/pull/',
         title: { ja: 'レビューコメント' },
         description: {
             ja: '特定の行やコードブロックに対するフィードバック。質問、提案、修正依頼などを記録できます。',

--- a/src/dictionary/entries/repository.ts
+++ b/src/dictionary/entries/repository.ts
@@ -419,49 +419,364 @@ export const repositoryEntries: DictionaryEntry[] = [
     },
 
     // === Hover Entries ===
+    // Star/Watch/Fork - リポジトリアクション
     {
         type: 'hover',
         id: 'hover-repo-star',
-        selector: 'a[href*="/stargazers"], button[data-ga-click*="star"]',
+        selector: '[data-view-component="true"][href$="/stargazers"], button[data-ga-click*="Star"], .starring-container button, .js-toggler-target:has(.octicon-star), .BtnGroup:has([aria-label*="Star"]) button',
         title: { ja: 'スター' },
         description: {
-            ja: 'リポジトリをお気に入りに追加する機能。後で簡単に見つけられ、プロジェクトへの関心を示すことができます。',
+            ja: 'リポジトリをお気に入りに追加する機能。後で簡単に見つけられ、プロジェクトへの関心を示すことができます。スター数はプロジェクトの人気度の指標にもなります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-unstar',
+        selector: '.js-toggler-target.starred, button[aria-label*="Unstar"], .BtnGroup button:has(.octicon-star-fill)',
+        title: { ja: 'スター解除' },
+        description: {
+            ja: 'このリポジトリへのスターを外します。スターを外してもリポジトリは引き続きアクセス可能です。',
         },
     },
     {
         type: 'hover',
         id: 'hover-repo-watch',
-        selector: '.pagehead-actions li:has([data-ga-click*="watch"]), details-menu.select-menu-modal:has([value="subscribed"])',
+        selector: '.js-notifications-container summary, details-menu[src*="notifications"], [data-target="notifications-list-subscription-form.menu"], summary[aria-label*="Watch"], summary[aria-label*="Notification"]',
         title: { ja: 'ウォッチ' },
         description: {
-            ja: 'リポジトリの更新通知を受け取れます。イシューやPRの作成・更新時に通知が届きます。',
+            ja: 'リポジトリの更新通知を受け取れます。「All Activity」で全通知、「Participating」で自分が参加するスレッドのみ、「Ignore」で通知を無効化できます。',
         },
     },
     {
         type: 'hover',
         id: 'hover-repo-fork',
-        selector: 'a[href*="/fork"], button[data-ga-click*="fork"]',
+        selector: '[data-view-component="true"][href$="/fork"], a[href*="/forks?fragment="], button[data-ga-click*="Fork"], .forks a, a[href$="/network/members"]',
         title: { ja: 'フォーク' },
         description: {
-            ja: 'リポジトリのコピーを自分のアカウントに作成します。元のプロジェクトに影響を与えずに変更できます。',
+            ja: 'リポジトリのコピーを自分のアカウントに作成します。元のプロジェクトに影響を与えずに自由に変更でき、後でプルリクエストを送って貢献できます。',
         },
     },
+    {
+        type: 'hover',
+        id: 'hover-repo-forked-from',
+        selector: '.fork-flag a, span.text-small:has(a[data-hovercard-type="repository"])',
+        title: { ja: 'フォーク元' },
+        description: {
+            ja: 'このリポジトリのフォーク元（オリジナル）のリポジトリへのリンク。フォークしたリポジトリは元のリポジトリとの同期が可能です。',
+        },
+    },
+
+    // Clone関連
+    {
+        type: 'hover',
+        id: 'hover-repo-clone-dropdown',
+        selector: 'get-repo summary, [data-target="get-repo.dropdownButton"], summary:has(.octicon-code):has(.octicon-triangle-down), details[data-analytics-event*="code button"]',
+        title: { ja: 'コードをダウンロード' },
+        description: {
+            ja: 'リポジトリをローカルにクローン、またはZIPでダウンロードできます。HTTPS、SSH、GitHub CLI の3つのクローン方法と、Codespacesでの開発も選択可能です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-clone-https',
+        selector: '[data-tab="https-tab"], tab-container [role="tab"][aria-selected*="true"]:has(.octicon-copy)',
+        title: { ja: 'HTTPSでクローン' },
+        description: {
+            ja: 'Git用のHTTPS URLを使用してクローン。認証にはユーザー名とパスワード（またはPersonal Access Token）が必要です。ファイアウォール環境でも動作しやすい方法です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-clone-ssh',
+        selector: '[data-tab="ssh-tab"], [role="tab"]:has(.ssh-clone-instructions)',
+        title: { ja: 'SSHでクローン' },
+        description: {
+            ja: 'SSH鍵を使用してクローン。事前にSSH鍵を生成してGitHubに登録する必要がありますが、毎回パスワード入力が不要になります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-clone-cli',
+        selector: '[data-tab="cli-tab"], [aria-controls*="github-cli"]',
+        title: { ja: 'GitHub CLIでクローン' },
+        description: {
+            ja: 'GitHub CLIコマンド (gh repo clone) を使用してクローン。GitHub CLIをインストールしている場合、最も簡単にクローンできます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-download-zip',
+        selector: 'a[href*="/archive/"], a[data-open-app*="download-link"], [data-ga-click*="Download ZIP"]',
+        title: { ja: 'ZIPダウンロード' },
+        description: {
+            ja: 'リポジトリの現在の状態をZIPファイルとしてダウンロード。Gitを使わずにソースコードを取得できますが、バージョン管理履歴は含まれません。',
+        },
+    },
+
+    // Codespaces
+    {
+        type: 'hover',
+        id: 'hover-repo-codespaces',
+        selector: '[data-target="codespace-selector.dropdownButton"], a[href*="/codespaces/new"], button[data-target="get-repo.codespaceButton"]',
+        title: { ja: 'Codespaces' },
+        description: {
+            ja: 'クラウド上の開発環境でこのリポジトリを開発できます。ローカルにセットアップ不要で、ブラウザ上のVS Codeで即座にコーディング開始できます。',
+        },
+    },
+
+    // Contributors/Insights
     {
         type: 'hover',
         id: 'hover-repo-contributor',
-        selector: 'a[href*="/graphs/contributors"]',
+        selector: 'a[href*="/graphs/contributors"], a[href$="/contributors"], .BorderGrid-cell a:has(img[alt*="@"])',
         title: { ja: 'コントリビューター' },
         description: {
-            ja: 'リポジトリに貢献した人々。コードのコミット、イシューの報告、プルリクエストの作成などで貢献できます。',
+            ja: 'リポジトリに貢献した人々の一覧とその統計。コミット数、追加/削除行数、貢献期間などを確認できます。',
         },
     },
     {
         type: 'hover',
+        id: 'hover-repo-stargazers',
+        selector: 'a[href$="/stargazers"], a[href*="/stargazers?"]',
+        title: { ja: 'スターした人' },
+        description: {
+            ja: 'このリポジトリをスターしたユーザーの一覧。プロジェクトに興味を持っている人々を確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-watchers',
+        selector: 'a[href$="/watchers"], a[href*="/watchers?"]',
+        title: { ja: 'ウォッチャー' },
+        description: {
+            ja: 'このリポジトリをウォッチしているユーザーの一覧。リポジトリの更新通知を受け取っている人々です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-network',
+        selector: 'a[href*="/network"], a[href$="/network/members"]',
+        title: { ja: 'ネットワーク' },
+        description: {
+            ja: 'フォークの関係を視覚的に表示。このリポジトリから派生したすべてのフォークと、それぞれの開発状況を確認できます。',
+        },
+    },
+
+    // Releases/Tags
+    {
+        type: 'hover',
         id: 'hover-repo-release',
-        selector: 'a[href*="/releases"]',
+        selector: 'a[href*="/releases"], .BorderGrid-cell a:has(.octicon-tag), h2:has(.octicon-package) + div a',
         title: { ja: 'リリース' },
         description: {
-            ja: 'ソフトウェアの配布可能なバージョン。タグに関連付けられ、変更履歴やバイナリファイルを含められます。',
+            ja: 'ソフトウェアの配布可能なバージョン。変更履歴（CHANGELOG）、ソースコードのZIP/TAR、ビルド済みバイナリなどが含まれます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-latest-release',
+        selector: 'a[href*="/releases/latest"], .release-entry [href*="/releases/tag/"]',
+        title: { ja: '最新リリース' },
+        description: {
+            ja: '最新の安定版リリース。通常はプレリリースを除いた最新バージョンを指します。バージョン番号とリリース日を確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-tag',
+        selector: 'a[href*="/tags"], .subnav-item[href*="/tags"], span.css-truncate:has(.octicon-tag)',
+        title: { ja: 'タグ' },
+        description: {
+            ja: 'Git履歴の特定のポイントに付けた目印（タグ）。リリースバージョンをマークするのに使われ、通常はv1.0.0のようなセマンティックバージョニングに従います。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-create-release',
+        selector: 'a[href*="/releases/new"], button:has([data-ga-click*="Release"])',
+        title: { ja: '新規リリース作成' },
+        description: {
+            ja: '新しいリリースを作成します。既存のタグを選択するか新規作成し、リリースノート、アセット（ビルド済みファイル）を追加できます。',
+        },
+    },
+
+    // Packages
+    {
+        type: 'hover',
+        id: 'hover-repo-packages',
+        selector: 'a[href*="/packages"], .BorderGrid-cell:has(.octicon-package) a',
+        title: { ja: 'パッケージ' },
+        description: {
+            ja: 'GitHub Packagesで公開されているパッケージの一覧。npm、Docker、Maven、NuGet、RubyGemsなどの形式で配布されています。',
+        },
+    },
+
+    // Environments/Deployments
+    {
+        type: 'hover',
+        id: 'hover-repo-environments',
+        selector: 'a[href*="/deployments"], .BorderGrid-cell:has(.octicon-server) a, a[href*="/settings/environments"]',
+        title: { ja: '環境（デプロイメント）' },
+        description: {
+            ja: 'GitHub Actionsからデプロイされた環境の一覧。production、staging、developmentなど、設定された各環境の状態とデプロイ履歴を確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-deployment-status',
+        selector: '.deployment-status, .branch-action-item .deployment-badge, [data-hovercard-type="deployment"]',
+        title: { ja: 'デプロイ状況' },
+        description: {
+            ja: 'このブランチ/コミットのデプロイ状況。成功・失敗・進行中などの状態と、デプロイ先の環境を表示します。',
+        },
+    },
+
+    // Topics
+    {
+        type: 'hover',
+        id: 'hover-repo-topics',
+        selector: 'a[href*="/topics/"], .topic-tag, [data-octo-click="topic_click"]',
+        title: { ja: 'トピック（タグ）' },
+        description: {
+            ja: 'リポジトリを分類するタグ。同じトピックを持つ他のリポジトリを発見しやすくなります。クリックすると同じトピックのリポジトリ一覧が表示されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-add-topics',
+        selector: 'button[aria-label*="topic"], .js-topics-edit-text, [data-target="topics-settings.editButton"]',
+        title: { ja: 'トピックを追加' },
+        description: {
+            ja: 'リポジトリにトピック（分類タグ）を追加します。プログラミング言語、フレームワーク、目的などを設定すると発見されやすくなります。',
+        },
+    },
+
+    // README/License
+    {
+        type: 'hover',
+        id: 'hover-repo-readme',
+        selector: 'a[href*="#readme"], #readme, article.markdown-body h1:first-child',
+        title: { ja: 'README' },
+        description: {
+            ja: 'リポジトリの説明書。プロジェクトの概要、インストール方法、使い方、貢献方法などを記載します。Markdownで記述され、リポジトリトップに表示されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-license',
+        selector: 'a[href*="/blob/"][href*="LICENSE"], .BorderGrid-cell:has(.octicon-law) a, [data-analytics-event*="LICENSE"]',
+        title: { ja: 'ライセンス' },
+        description: {
+            ja: 'ソフトウェアの利用条件を定義するライセンス。MIT、Apache 2.0、GPLなど様々な種類があり、このコードをどう使用できるかが規定されています。',
+        },
+    },
+
+    // About/Description
+    {
+        type: 'hover',
+        id: 'hover-repo-about',
+        selector: '.BorderGrid-cell h2.h4, .repository-content .BorderGrid-cell:first-child, [data-target="readme-toc.content"] + div',
+        title: { ja: 'About（リポジトリ概要）' },
+        description: {
+            ja: 'リポジトリの概要説明、ウェブサイトURL、トピックが表示されるセクション。右側のサイドバーに配置され、プロジェクトの要約を提供します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-edit-about',
+        selector: 'button[aria-label*="Edit repository"], [data-target="edit-repository-details.detailsButton"], .BorderGrid h2.h4 + button',
+        title: { ja: 'リポジトリ詳細を編集' },
+        description: {
+            ja: 'リポジトリの説明、ウェブサイトURL、トピックを編集できます。リポジトリの管理者のみ編集可能です。',
+        },
+    },
+
+    // Visibility badges
+    {
+        type: 'hover',
+        id: 'hover-repo-public-badge',
+        selector: '.Label--secondary:has(.octicon-repo), span.Label:contains("Public"), .repo-private-label-lockup .Label',
+        title: { ja: 'パブリック' },
+        description: {
+            ja: 'このリポジトリは公開されており、誰でもアクセス・クローン可能です。検索結果にも表示されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-private-badge',
+        selector: '.Label--attention:has(.octicon-lock), span.Label:contains("Private"), .private-label',
+        title: { ja: 'プライベート' },
+        description: {
+            ja: 'このリポジトリは非公開で、招待されたコラボレーターのみがアクセスできます。検索結果には表示されません。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-archived-badge',
+        selector: '.Label--warning:has(.octicon-archive), [aria-label*="archived"], .flash-warn:has(.octicon-archive)',
+        title: { ja: 'アーカイブ済み' },
+        description: {
+            ja: 'このリポジトリは読み取り専用になっています。新しいコミット、イシュー、プルリクエストは作成できませんが、クローンやフォークは可能です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-template-badge',
+        selector: '.Label:contains("Template"), [aria-label*="template"], .octicon-repo-template',
+        title: { ja: 'テンプレート' },
+        description: {
+            ja: 'このリポジトリはテンプレートとして設定されています。「Use this template」から新しいリポジトリをこのテンプレートを元に作成できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-use-template',
+        selector: 'a[href*="/generate"], button:has([data-ga-click*="Use this template"])',
+        title: { ja: 'テンプレートを使用' },
+        description: {
+            ja: 'このテンプレートリポジトリを元に新しいリポジトリを作成します。フォークと異なり、履歴は継承されず新しいリポジトリとして開始されます。',
+        },
+    },
+
+    // Activity
+    {
+        type: 'hover',
+        id: 'hover-repo-activity',
+        selector: 'a[href*="/activity"], .BorderGrid-cell:has(.octicon-pulse) a',
+        title: { ja: 'アクティビティ' },
+        description: {
+            ja: 'リポジトリでの最近の活動一覧。コミット、プルリクエスト、イシュー、ディスカッションなどの更新履歴を時系列で確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-repo-insights',
+        selector: 'a[href*="/pulse"], nav[aria-label="Repository"] a[href*="/pulse"]',
+        title: { ja: 'Pulse（活動状況）' },
+        description: {
+            ja: 'リポジトリの活動サマリー。過去1週間/1ヶ月のプルリクエスト数、イシュー数、コントリビューター数などの統計を確認できます。',
+        },
+    },
+
+    // Pin repository
+    {
+        type: 'hover',
+        id: 'hover-repo-pin',
+        selector: 'form[action*="/pin"], button[aria-label*="Pin"]',
+        title: { ja: 'リポジトリをピン留め' },
+        description: {
+            ja: 'このリポジトリをプロフィールにピン留めします。ピン留めしたリポジトリはプロフィールのトップに表示され、最大6つまで設定可能です。',
+        },
+    },
+
+    // Sponsor
+    {
+        type: 'hover',
+        id: 'hover-repo-sponsor',
+        selector: 'a[href*="/sponsors/"], button.js-sponsor-button, .BorderGrid-cell:has(.octicon-heart) a',
+        title: { ja: 'スポンサー' },
+        description: {
+            ja: 'このプロジェクトやメンテナーに対して、GitHub Sponsorsを通じて金銭的に支援できます。月額または一時払いで寄付が可能です。',
         },
     },
 ];

--- a/src/dictionary/entries/repository.ts
+++ b/src/dictionary/entries/repository.ts
@@ -695,7 +695,7 @@ export const repositoryEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-repo-public-badge',
-        selector: '.Label--secondary:has(.octicon-repo), span.Label:contains("Public"), .repo-private-label-lockup .Label',
+        selector: '.Label--secondary[title="Public"], span.Label[title="Public"], .repo-private-label-lockup .Label, [data-testid="repo-visibility-badge"]:not([title*="Private"])',
         title: { ja: 'パブリック' },
         description: {
             ja: 'このリポジトリは公開されており、誰でもアクセス・クローン可能です。検索結果にも表示されます。',
@@ -704,7 +704,7 @@ export const repositoryEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-repo-private-badge',
-        selector: '.Label--attention:has(.octicon-lock), span.Label:contains("Private"), .private-label',
+        selector: '.Label--attention[title="Private"], span.Label[title="Private"], .private-label, [data-testid="repo-visibility-badge"][title*="Private"]',
         title: { ja: 'プライベート' },
         description: {
             ja: 'このリポジトリは非公開で、招待されたコラボレーターのみがアクセスできます。検索結果には表示されません。',
@@ -713,7 +713,7 @@ export const repositoryEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-repo-archived-badge',
-        selector: '.Label--warning:has(.octicon-archive), [aria-label*="archived"], .flash-warn:has(.octicon-archive)',
+        selector: '.Label--warning[aria-label*="archived"], [aria-label*="archived"], .flash-warn .octicon-archive',
         title: { ja: 'アーカイブ済み' },
         description: {
             ja: 'このリポジトリは読み取り専用になっています。新しいコミット、イシュー、プルリクエストは作成できませんが、クローンやフォークは可能です。',
@@ -722,7 +722,7 @@ export const repositoryEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-repo-template-badge',
-        selector: '.Label:contains("Template"), [aria-label*="template"], .octicon-repo-template',
+        selector: 'span.Label[title="Template"], [aria-label*="template"], .octicon-repo-template',
         title: { ja: 'テンプレート' },
         description: {
             ja: 'このリポジトリはテンプレートとして設定されています。「Use this template」から新しいリポジトリをこのテンプレートを元に作成できます。',
@@ -731,7 +731,7 @@ export const repositoryEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-repo-use-template',
-        selector: 'a[href*="/generate"], button:has([data-ga-click*="Use this template"])',
+        selector: 'a[href*="/generate"], button[data-ga-click*="Use this template"]',
         title: { ja: 'テンプレートを使用' },
         description: {
             ja: 'このテンプレートリポジトリを元に新しいリポジトリを作成します。フォークと異なり、履歴は継承されず新しいリポジトリとして開始されます。',

--- a/src/dictionary/entries/ui-elements.ts
+++ b/src/dictionary/entries/ui-elements.ts
@@ -1392,7 +1392,7 @@ export const uiElementsEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-avatar',
-        selector: '.avatar, [class*="avatar"]',
+        selector: '.avatar, .Avatar, img.avatar, [data-testid="avatar"]',
         title: { ja: 'アバター' },
         description: {
             ja: 'ユーザーのプロフィール画像。クリックするとそのユーザーのプロフィールページに移動できます。',
@@ -1402,7 +1402,7 @@ export const uiElementsEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-counter-badge',
-        selector: '.Counter, [class*="counter"]',
+        selector: '.Counter, span.Counter',
         title: { ja: 'カウンターバッジ' },
         description: {
             ja: '数量を示すバッジ。未読通知数、イシュー数、コメント数などを表示します。',

--- a/src/dictionary/entries/ui-elements.ts
+++ b/src/dictionary/entries/ui-elements.ts
@@ -1046,4 +1046,404 @@ export const uiElementsEntries: DictionaryEntry[] = [
             ja: '読み取り専用になったリポジトリ。新しいイシューやPRは作成できませんが、コードとヒストリーは保持されます。',
         },
     },
+    // ボタン関連
+    {
+        type: 'hover',
+        id: 'hover-submit-button',
+        selector: 'button[type="submit"], .btn-primary',
+        title: { ja: '送信ボタン' },
+        description: {
+            ja: 'フォームの内容を送信します。コメント投稿、イシュー作成、設定保存などに使用されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-cancel-button',
+        selector: '.btn-danger:not([type="submit"]), [data-close-dialog]',
+        title: { ja: 'キャンセルボタン' },
+        description: {
+            ja: '現在の操作を中止し、前の状態に戻ります。入力した内容は保存されません。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-edit-button',
+        selector: '[aria-label*="Edit"], .js-blob-edit-link, a[href*="/edit/"]',
+        title: { ja: '編集ボタン' },
+        description: {
+            ja: 'ファイル、コメント、イシュー、プロフィールなどを編集モードに切り替えます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-delete-button',
+        selector: '[aria-label*="Delete"], .btn-danger[type="submit"]',
+        title: { ja: '削除ボタン' },
+        description: {
+            ja: '要素を完全に削除します。多くの場合、確認ダイアログが表示されます。一部の削除は元に戻せません。',
+        },
+    },
+    // ドロップダウン・メニュー
+    {
+        type: 'hover',
+        id: 'hover-dropdown-menu',
+        selector: '.SelectMenu, [data-menu-button], details.dropdown',
+        title: { ja: 'ドロップダウンメニュー' },
+        description: {
+            ja: 'クリックすると選択肢のリストが表示されます。フィルタ、ソート、アクションの選択に使用されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-context-menu',
+        selector: '[role="menu"], .ActionListWrap',
+        title: { ja: 'コンテキストメニュー' },
+        description: {
+            ja: '右クリックまたはメニューボタンで表示されるアクションリスト。要素に対する操作を選択できます。',
+        },
+    },
+    // タブ・ナビゲーション
+    {
+        type: 'hover',
+        id: 'hover-tab-nav',
+        selector: '[role="tablist"], .UnderlineNav-body',
+        title: { ja: 'タブナビゲーション' },
+        description: {
+            ja: 'セクション間を切り替えるタブ。Code、Issues、Pull requests、Actionsなどのメインタブがあります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pagination',
+        selector: '.pagination, [class*="paginate"]',
+        title: { ja: 'ページネーション' },
+        description: {
+            ja: 'コンテンツが複数ページある場合のページ切り替え。Previous/Nextまたはページ番号をクリックして移動します。',
+        },
+    },
+    // モーダル・ダイアログ
+    {
+        type: 'hover',
+        id: 'hover-modal-dialog',
+        selector: '[role="dialog"], .Box-overlay, .Overlay',
+        title: { ja: 'モーダルダイアログ' },
+        description: {
+            ja: '画面の上に重なって表示されるウィンドウ。確認や入力が必要な場合に使用されます。閉じるまで背景は操作できません。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-confirm-dialog',
+        selector: '.js-confirm-dialog, [data-confirm-dialog]',
+        title: { ja: '確認ダイアログ' },
+        description: {
+            ja: '重要な操作の前に表示される確認。削除やマージなどの取り消せない操作の前に確認を求めます。',
+        },
+    },
+    // フォーム要素
+    {
+        type: 'hover',
+        id: 'hover-text-input',
+        selector: 'input[type="text"], input:not([type]), .form-control',
+        title: { ja: 'テキスト入力フィールド' },
+        description: {
+            ja: 'テキストを入力するフィールド。タイトル、検索クエリ、ブランチ名などの入力に使用されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-textarea',
+        selector: 'textarea, .comment-form-textarea',
+        title: { ja: 'テキストエリア' },
+        description: {
+            ja: '複数行のテキストを入力するフィールド。コメント、説明、PRの本文などに使用されます。Markdownがサポートされることが多いです。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-checkbox',
+        selector: 'input[type="checkbox"], .form-checkbox',
+        title: { ja: 'チェックボックス' },
+        description: {
+            ja: 'オン/オフを切り替える要素。複数選択可能な設定やタスクリストに使用されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-radio',
+        selector: 'input[type="radio"], .form-radio',
+        title: { ja: 'ラジオボタン' },
+        description: {
+            ja: '複数の選択肢から1つを選ぶ要素。マージ方法やリポジトリの可視性選択などに使用されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-select',
+        selector: 'select, .form-select',
+        title: { ja: 'セレクトボックス' },
+        description: {
+            ja: 'ドロップダウンリストから選択する要素。ブランチ選択、言語フィルタなどに使用されます。',
+        },
+    },
+    // 検索・フィルタ
+    {
+        type: 'hover',
+        id: 'hover-search-input',
+        selector: '[type="search"], .js-site-search-focus, .subnav-search-input',
+        title: { ja: '検索フィールド' },
+        description: {
+            ja: 'キーワードで検索します。Enterキーで検索実行。高度な検索修飾子も使用できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-filter-bar',
+        selector: '.subnav, .table-list-filters',
+        title: { ja: 'フィルタバー' },
+        description: {
+            ja: 'リストの表示内容を絞り込むフィルタ。ステータス、ラベル、作成者などで絞り込めます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-sort-menu',
+        selector: '.select-menu[class*="sort"], [aria-label*="Sort"]',
+        title: { ja: 'ソートメニュー' },
+        description: {
+            ja: 'リストの並び順を変更します。日付順、人気順、アルファベット順などで並べ替えられます。',
+        },
+    },
+    // ローディング・状態表示
+    {
+        type: 'hover',
+        id: 'hover-loading',
+        selector: '[class*="loading"], .AnimatedEllipsis, [aria-busy="true"]',
+        title: { ja: '読み込み中' },
+        description: {
+            ja: 'コンテンツを読み込んでいます。操作完了まで少しお待ちください。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-spinner',
+        selector: '.Spinner, [class*="spinner"]',
+        title: { ja: 'スピナー' },
+        description: {
+            ja: '処理中を示すアニメーション。バックグラウンドで操作が進行中です。',
+        },
+    },
+    // 通知・アラート
+    {
+        type: 'hover',
+        id: 'hover-flash-message',
+        selector: '.flash, [role="alert"]',
+        title: { ja: 'フラッシュメッセージ' },
+        description: {
+            ja: '操作の結果を通知するメッセージ。成功（緑）、警告（黄）、エラー（赤）、情報（青）があります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-banner',
+        selector: '.Banner, [class*="banner"]',
+        title: { ja: 'バナー' },
+        description: {
+            ja: '重要なお知らせを表示するバー。メンテナンス通知、新機能案内、警告などが表示されます。',
+        },
+    },
+    // ツールチップ・ポップオーバー
+    {
+        type: 'hover',
+        id: 'hover-tooltip',
+        selector: '[role="tooltip"], .tooltipped',
+        title: { ja: 'ツールチップ' },
+        description: {
+            ja: '要素にホバーすると表示される補足情報。アイコンやボタンの説明が表示されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-popover',
+        selector: '.Popover, [data-content]',
+        title: { ja: 'ポップオーバー' },
+        description: {
+            ja: 'クリックで表示される情報ボックス。詳細情報やアクション選択肢が表示されます。',
+        },
+    },
+    // トグル・スイッチ
+    {
+        type: 'hover',
+        id: 'hover-toggle-switch',
+        selector: '.ToggleSwitch, [role="switch"]',
+        title: { ja: 'トグルスイッチ' },
+        description: {
+            ja: '機能のオン/オフを切り替えるスイッチ。クリックで即座に設定が変更されます。',
+        },
+    },
+    // コピー・共有
+    {
+        type: 'hover',
+        id: 'hover-copy-button',
+        selector: '.js-clipboard-copy, [data-copy-feedback], clipboard-copy',
+        title: { ja: 'コピーボタン' },
+        description: {
+            ja: 'テキストをクリップボードにコピーします。URL、SHA、コマンドなどを素早くコピーできます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-share-button',
+        selector: '[aria-label*="Share"], [class*="share"]',
+        title: { ja: '共有ボタン' },
+        description: {
+            ja: 'コンテンツを他の人と共有します。リンクのコピーやSNSで共有ができます。',
+        },
+    },
+    // マークダウン関連
+    {
+        type: 'hover',
+        id: 'hover-markdown-preview',
+        selector: '.preview-tab, [data-preview-panel-id]',
+        title: { ja: 'プレビュータブ' },
+        description: {
+            ja: 'Markdownのレンダリング結果をプレビュー表示します。投稿前に見た目を確認できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-markdown-write',
+        selector: '.write-tab, [data-write-button]',
+        title: { ja: '編集タブ' },
+        description: {
+            ja: 'Markdownテキストを編集するモード。ツールバーでフォーマットを適用できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-markdown-toolbar',
+        selector: '.toolbar-commenting, md-header',
+        title: { ja: 'Markdownツールバー' },
+        description: {
+            ja: 'テキストにフォーマットを適用するためのツールバー。太字、リンク、リスト、コードブロックなどを挿入できます。',
+        },
+    },
+    // ファイルアップロード
+    {
+        type: 'hover',
+        id: 'hover-file-upload',
+        selector: '.js-upload-markdown-image, [data-upload-policy-url]',
+        title: { ja: 'ファイルアップロード' },
+        description: {
+            ja: '画像やファイルをアップロードします。ドラッグ＆ドロップまたはクリックしてファイルを選択できます。',
+        },
+    },
+    // サイドバー
+    {
+        type: 'hover',
+        id: 'hover-sidebar',
+        selector: '.Layout-sidebar, [class*="sidebar"]',
+        title: { ja: 'サイドバー' },
+        description: {
+            ja: 'ページの補足情報やナビゲーションを表示するサイドパネル。About、ラベル、マイルストーンなどが表示されます。',
+        },
+    },
+    // フッター
+    {
+        type: 'hover',
+        id: 'hover-footer',
+        selector: 'footer, .footer',
+        title: { ja: 'フッター' },
+        description: {
+            ja: 'ページ下部のリンク集。利用規約、プライバシーポリシー、ドキュメント、APIなどへのリンクがあります。',
+        },
+    },
+    // 展開・折りたたみ
+    {
+        type: 'hover',
+        id: 'hover-expand-collapse',
+        selector: '[aria-expanded], details summary',
+        title: { ja: '展開/折りたたみ' },
+        description: {
+            ja: 'クリックでコンテンツを表示/非表示にします。長いリストや詳細情報を整理するのに使用されます。',
+        },
+    },
+    // 絵文字ピッカー
+    {
+        type: 'hover',
+        id: 'hover-emoji-picker',
+        selector: '.emoji-picker-container, [data-emoji-picker]',
+        title: { ja: '絵文字ピッカー' },
+        description: {
+            ja: 'コメントやリアクションに絵文字を追加できます。検索やカテゴリから選択できます。',
+        },
+    },
+    // リアクション
+    {
+        type: 'hover',
+        id: 'hover-reactions',
+        selector: '.js-reaction-group-container, .comment-reactions',
+        title: { ja: 'リアクション' },
+        description: {
+            ja: 'コメントやイシューに対する絵文字リアクション。👍 👎 😄 🎉 😕 ❤️ 🚀 👀 から選べます。',
+        },
+    },
+    // アバター
+    {
+        type: 'hover',
+        id: 'hover-avatar',
+        selector: '.avatar, [class*="avatar"]',
+        title: { ja: 'アバター' },
+        description: {
+            ja: 'ユーザーのプロフィール画像。クリックするとそのユーザーのプロフィールページに移動できます。',
+        },
+    },
+    // バッジ・ラベル
+    {
+        type: 'hover',
+        id: 'hover-counter-badge',
+        selector: '.Counter, [class*="counter"]',
+        title: { ja: 'カウンターバッジ' },
+        description: {
+            ja: '数量を示すバッジ。未読通知数、イシュー数、コメント数などを表示します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-state-label',
+        selector: '.State, .IssueLabel',
+        title: { ja: 'ステートラベル' },
+        description: {
+            ja: '状態を示すラベル。Open（緑）、Closed（赤/紫）、Merged（紫）などがあります。',
+        },
+    },
+    // コード表示関連
+    {
+        type: 'hover',
+        id: 'hover-line-numbers',
+        selector: '.blob-num, [data-line-number]',
+        title: { ja: '行番号' },
+        description: {
+            ja: 'コードの行番号。クリックで特定の行をハイライトし、その行へのパーマリンクを生成できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-syntax-highlight',
+        selector: '.blob-code, .highlight',
+        title: { ja: 'シンタックスハイライト' },
+        description: {
+            ja: 'コードの構文を色分けして表示。キーワード、文字列、コメントなどが識別しやすくなります。',
+        },
+    },
+    // 時間表示
+    {
+        type: 'hover',
+        id: 'hover-relative-time',
+        selector: 'relative-time, time-ago',
+        title: { ja: '相対時間' },
+        description: {
+            ja: '「3日前」「2時間前」などの相対的な時間表示。ホバーすると正確な日時が表示されます。',
+        },
+    },
 ];

--- a/src/dictionary/entries/users-orgs.ts
+++ b/src/dictionary/entries/users-orgs.ts
@@ -678,4 +678,375 @@ export const usersOrgsEntries: DictionaryEntry[] = [
             ja: 'コミット、プルリクエスト、イシュー、レビューなど、プロジェクトへの貢献。草グラフで可視化されます。',
         },
     },
+    // プロフィール
+    {
+        type: 'hover',
+        id: 'hover-profile-overview',
+        selector: 'a[data-tab="overview"], [aria-label*="Overview"]',
+        title: { ja: '概要' },
+        description: {
+            ja: 'ユーザーのプロフィール概要。ピン留めリポジトリ、アクティビティ、バイオを表示します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-profile-repos',
+        selector: 'a[data-tab="repositories"]',
+        title: { ja: 'リポジトリタブ' },
+        description: {
+            ja: 'ユーザーが所有または貢献しているリポジトリの一覧を表示します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-profile-projects',
+        selector: 'a[data-tab="projects"]',
+        title: { ja: 'プロジェクトタブ' },
+        description: {
+            ja: 'ユーザーが作成したプロジェクトボードの一覧を表示します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-profile-packages',
+        selector: 'a[data-tab="packages"]',
+        title: { ja: 'パッケージタブ' },
+        description: {
+            ja: 'ユーザーが公開しているパッケージの一覧を表示します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-profile-stars',
+        selector: 'a[data-tab="stars"], a[href*="/stars"]',
+        title: { ja: 'スター' },
+        description: {
+            ja: 'ユーザーがスターを付けたリポジトリの一覧。お気に入りや関心のあるプロジェクトです。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-profile-edit',
+        selector: 'a[href*="/settings/profile"]',
+        title: { ja: 'プロフィール編集' },
+        description: {
+            ja: '名前、バイオ、アバター、SNSリンクなどのプロフィール情報を編集します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-profile-avatar',
+        selector: '.avatar, [data-testid="avatar"]',
+        title: { ja: 'アバター' },
+        description: {
+            ja: 'ユーザーのプロフィール画像。クリックするとプロフィールページに移動します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-profile-pinned',
+        selector: '.js-pinned-items-reorder-container',
+        title: { ja: 'ピン留め' },
+        description: {
+            ja: 'プロフィールに固定表示するリポジトリ。最大6つまでピン留めできます。',
+        },
+    },
+    // フォロー
+    {
+        type: 'hover',
+        id: 'hover-follow-button',
+        selector: 'button[value="follow"], [aria-label*="Follow"]',
+        title: { ja: 'フォロー' },
+        description: {
+            ja: 'このユーザーをフォロー。フィードでアクティビティを追跡できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-unfollow-button',
+        selector: 'button[value="unfollow"]',
+        title: { ja: 'フォロー解除' },
+        description: {
+            ja: 'このユーザーのフォローを解除します。',
+        },
+    },
+    // 組織
+    {
+        type: 'hover',
+        id: 'hover-org-people',
+        selector: 'a[href*="/people"], a[href*="/members"]',
+        title: { ja: 'メンバー' },
+        description: {
+            ja: '組織に所属するメンバーの一覧。オーナー、メンテナー、メンバーなどのロールがあります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-org-invite',
+        selector: 'button[data-hovercard-type="invite"], [aria-label*="Invite"]',
+        title: { ja: 'メンバーを招待' },
+        description: {
+            ja: '新しいメンバーを組織に招待します。招待されたユーザーは承諾が必要です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-org-pending',
+        selector: 'a[href*="/pending_invitations"]',
+        title: { ja: '保留中の招待' },
+        description: {
+            ja: 'まだ承諾されていない招待の一覧。有効期限が切れると再送信が必要です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-org-outside-collaborators',
+        selector: 'a[href*="/outside_collaborators"]',
+        title: { ja: '外部コラボレーター' },
+        description: {
+            ja: '組織メンバーではないが、特定のリポジトリにアクセス権を持つユーザー。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-org-billing',
+        selector: 'a[href*="/billing"]',
+        title: { ja: '請求' },
+        description: {
+            ja: '組織のプラン、使用状況、支払い情報を管理します。',
+        },
+    },
+    // チーム
+    {
+        type: 'hover',
+        id: 'hover-team-create',
+        selector: 'a[href*="/teams/new"], button[data-action*="create-team"]',
+        title: { ja: 'チームを作成' },
+        description: {
+            ja: '新しいチームを作成。メンバーをグループ化してアクセス権限を管理します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-team-members',
+        selector: 'a[href*="/team/"][href*="/members"]',
+        title: { ja: 'チームメンバー' },
+        description: {
+            ja: 'チームに所属するメンバーの一覧。メンテナーとメンバーの区別があります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-team-repos',
+        selector: 'a[href*="/team/"][href*="/repositories"]',
+        title: { ja: 'チームリポジトリ' },
+        description: {
+            ja: 'チームがアクセスできるリポジトリの一覧と権限レベル。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-team-discussions',
+        selector: 'a[href*="/team/"][href*="/discussions"]',
+        title: { ja: 'チームディスカッション' },
+        description: {
+            ja: 'チーム内での議論や意思決定のためのディスカッションスペース。',
+        },
+    },
+    // 権限
+    {
+        type: 'hover',
+        id: 'hover-permission-read',
+        selector: '[value="read"], [data-permission="read"]',
+        title: { ja: '読み取り' },
+        description: {
+            ja: 'コードの閲覧とクローンが可能。プルリクエストやイシューの作成も可能。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-permission-triage',
+        selector: '[value="triage"], [data-permission="triage"]',
+        title: { ja: 'トリアージ' },
+        description: {
+            ja: 'イシューとプルリクエストの管理が可能。ラベル付け、マイルストーン設定など。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-permission-write',
+        selector: '[value="write"], [data-permission="write"]',
+        title: { ja: '書き込み' },
+        description: {
+            ja: 'コードのプッシュ、ブランチの管理が可能。プルリクエストのマージも可能。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-permission-maintain',
+        selector: '[value="maintain"], [data-permission="maintain"]',
+        title: { ja: 'メンテナンス' },
+        description: {
+            ja: 'リポジトリの一部設定が可能。機密性の高い操作以外の管理タスクを実行できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-permission-admin',
+        selector: '[value="admin"], [data-permission="admin"]',
+        title: { ja: '管理者' },
+        description: {
+            ja: 'リポジトリのすべての操作が可能。削除や設定変更も含む完全なアクセス権限。',
+        },
+    },
+    // 通知
+    {
+        type: 'hover',
+        id: 'hover-notifications',
+        selector: 'a[href*="/notifications"]',
+        title: { ja: '通知' },
+        description: {
+            ja: '@メンション、参加中のディスカッション、ウォッチ中のリポジトリの更新情報。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-notification-inbox',
+        selector: '.notification-shelf',
+        title: { ja: '通知インボックス' },
+        description: {
+            ja: '未読の通知を管理。フィルタリング、既読化、購読解除が可能です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-notification-settings',
+        selector: 'a[href*="/notifications/settings"]',
+        title: { ja: '通知設定' },
+        description: {
+            ja: 'どのイベントで通知を受け取るか設定。メール、Web、モバイルの設定が可能。',
+        },
+    },
+    // スポンサー
+    {
+        type: 'hover',
+        id: 'hover-sponsor-button',
+        selector: 'a[href*="/sponsors/"], button[data-ga-click*="sponsor"]',
+        title: { ja: 'スポンサー' },
+        description: {
+            ja: 'このユーザーの活動を金銭的にサポート。毎月の寄付を設定できます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-sponsoring',
+        selector: 'a[href*="/sponsoring"]',
+        title: { ja: 'スポンサー中' },
+        description: {
+            ja: 'あなたが支援しているユーザーや組織の一覧。',
+        },
+    },
+    // セキュリティ
+    {
+        type: 'hover',
+        id: 'hover-ssh-keys',
+        selector: 'a[href*="/settings/keys"]',
+        title: { ja: 'SSHキー' },
+        description: {
+            ja: 'SSHでの認証に使用する公開鍵。パスワードなしでgit操作が可能になります。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-gpg-keys',
+        selector: 'a[href*="/settings/gpg"]',
+        title: { ja: 'GPGキー' },
+        description: {
+            ja: 'コミットへの署名に使用するGPGキー。署名されたコミットはVerifiedと表示されます。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-pat',
+        selector: 'a[href*="/settings/tokens"]',
+        title: { ja: '個人アクセストークン' },
+        description: {
+            ja: 'APIやコマンドラインでの認証に使用するトークン。パスワードの代わりに使用します。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-2fa',
+        selector: 'a[href*="/two_factor_authentication"]',
+        title: { ja: '二要素認証' },
+        description: {
+            ja: 'パスワードに加えて、認証アプリまたはSMSでの確認を要求。アカウントセキュリティを強化します。',
+        },
+    },
+    // ブロック・報告
+    {
+        type: 'hover',
+        id: 'hover-block-user',
+        selector: '[data-action*="block"]',
+        title: { ja: 'ユーザーをブロック' },
+        description: {
+            ja: 'このユーザーからの@メンション、コメント、プルリクエストをブロックします。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-report-user',
+        selector: '[data-action*="report"]',
+        title: { ja: '報告' },
+        description: {
+            ja: '不正行為やコミュニティガイドライン違反をGitHubに報告します。',
+        },
+    },
+    // コントリビューショングラフ
+    {
+        type: 'hover',
+        id: 'hover-contrib-graph',
+        selector: '.js-calendar-graph, [data-testid="contribution-graph"]',
+        title: { ja: 'コントリビューショングラフ' },
+        description: {
+            ja: '過去1年間の活動を日ごとに表示。色が濃いほど多くの活動があった日です。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-contrib-activity',
+        selector: '.contribution-activity, [data-testid="activity-timeline"]',
+        title: { ja: 'アクティビティタイムライン' },
+        description: {
+            ja: 'コミット、プルリクエスト、イシュー、レビューなどの活動履歴を時系列で表示。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-contrib-streak',
+        selector: '.contrib-streak',
+        title: { ja: '連続活動日数' },
+        description: {
+            ja: '連続してコントリビューションを行った日数。継続的な活動を可視化します。',
+        },
+    },
+    // アプリ
+    {
+        type: 'hover',
+        id: 'hover-oauth-apps',
+        selector: 'a[href*="/settings/applications"]',
+        title: { ja: 'OAuthアプリ' },
+        description: {
+            ja: 'あなたのアカウントへのアクセスを許可したサードパーティアプリの一覧。',
+        },
+    },
+    {
+        type: 'hover',
+        id: 'hover-github-apps',
+        selector: 'a[href*="/settings/installations"]',
+        title: { ja: 'GitHub Apps' },
+        description: {
+            ja: 'インストールしたGitHub Appsの一覧。リポジトリへのアクセス権限を管理できます。',
+        },
+    },
 ];


### PR DESCRIPTION
Adds 300+ hover entries across all 9 dictionary files for comprehensive Ctrl+hover explanations on GitHub.