### PR TITLE
Integrate hardcoded tooltip into generic hover system

### DIFF
--- a/src/content/hover.ts
+++ b/src/content/hover.ts
@@ -24,7 +24,7 @@ function handleMouseOver(e: MouseEvent) {
   if (!(e.ctrlKey || e.metaKey)) return;
 
   const target = e.target;
-  if (!(target instanceof HTMLElement)) return;
+  if (!(target instanceof Element)) return;
 
   // Optimization: if we are already in currentAnchor, do nothing
   if (currentAnchor && currentAnchor.contains(target)) {

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -8,57 +8,6 @@ interface GittohabulMessage {
   type: 'hotReload' | 'getStatus';
 }
 
-/** ツールチップ表示用の型定義 */
-interface TooltipOptions {
-  anchor: Element;
-  title: string;
-  text: string;
-}
-
-let tooltipElement: HTMLDivElement | null = null;
-
-function showTooltip({ anchor, title, text }: TooltipOptions): void {
-  hideTooltip();
-
-  tooltipElement = document.createElement('div');
-  tooltipElement.style.cssText = `
-    position: absolute;
-    z-index: 9999;
-    background: #24292f;
-    color: #fff;
-    border-radius: 6px;
-    padding: 8px 12px;
-    font-size: 12px;
-    max-width: 300px;
-    box-shadow: 0 8px 24px rgba(140, 149, 159, 0.2);
-    pointer-events: none;
-  `;
-
-  const titleEl = document.createElement('div');
-  titleEl.style.fontWeight = 'bold';
-  titleEl.style.marginBottom = '4px';
-  titleEl.textContent = title;
-
-  const textEl = document.createElement('div');
-  textEl.textContent = text;
-
-  tooltipElement.appendChild(titleEl);
-  tooltipElement.appendChild(textEl);
-  document.body.appendChild(tooltipElement);
-
-  const rect = anchor.getBoundingClientRect();
-  const tooltipRect = tooltipElement.getBoundingClientRect();
-  tooltipElement.style.left = `${rect.left + window.scrollX + (rect.width - tooltipRect.width) / 2}px`;
-  tooltipElement.style.top = `${rect.bottom + window.scrollY + 8}px`;
-}
-
-function hideTooltip(): void {
-  if (tooltipElement && tooltipElement.parentNode) {
-    tooltipElement.parentNode.removeChild(tooltipElement);
-    tooltipElement = null;
-  }
-}
-
 async function init(): Promise<void> {
   console.log('[gittohabu] Initializing...');
 
@@ -78,49 +27,6 @@ async function init(): Promise<void> {
     startObserver();
   }
 
-  // TODO: https://github.com/Hiroki-org/gittohabu/issues/5 ツールチップUI統合（hover設定の再利用）
-  document.addEventListener('mouseover', (e: MouseEvent) => {
-    if (!(e.ctrlKey || e.metaKey)) {
-      return;
-    }
-    const target = e.target;
-    // Fix: Use Element instead of HTMLElement to support SVG children (icons)
-    if (!(target instanceof Element)) {
-      return;
-    }
-    const anchor = target.closest('.btn-primary');
-    if (!(anchor instanceof Element)) {
-      return;
-    }
-    // Simulate mouseenter: verify we are not coming from a child
-    if (e.relatedTarget instanceof Node && anchor.contains(e.relatedTarget)) {
-      return;
-    }
-
-    showTooltip({
-      anchor,
-      title: 'Create pull request',
-      text: 'プルリクエストを作成するボタンです．変更をレビュー依頼したい時に使います．',
-    });
-  });
-
-  document.addEventListener('mouseout', (e: MouseEvent) => {
-    const target = e.target;
-    // Fix: Use Element instead of HTMLElement to support SVG children (icons)
-    if (!(target instanceof Element)) {
-      return;
-    }
-    const anchor = target.closest('.btn-primary');
-    if (!(anchor instanceof Element)) {
-      return;
-    }
-    // Simulate mouseleave: verify we are not going to a child
-    if (e.relatedTarget instanceof Node && anchor.contains(e.relatedTarget)) {
-      return;
-    }
-
-    hideTooltip();
-  });
 
   console.log('[gittohabu] Initialized with', replaceEntries.length, 'replace entries');
 }

--- a/src/dictionary/entries/pull-requests.ts
+++ b/src/dictionary/entries/pull-requests.ts
@@ -305,7 +305,7 @@ export const pullRequestEntries: DictionaryEntry[] = [
     {
         type: 'hover',
         id: 'hover-create-pr-button',
-        selector: 'button.btn-primary.js-details-target, a.btn-primary[href*="/compare"], a.btn-primary[href*="/pull/new"], form[action*="/pull/create"] .btn-primary',
+        selector: 'a.btn-primary[href*="/compare"], a.btn-primary[href*="/pull/new"], form[action*="/pull/create"] .btn-primary',
         title: { ja: 'Create pull request' },
         description: {
             ja: 'プルリクエストを作成するボタンです．変更をレビュー依頼したい時に使います．',

--- a/src/dictionary/entries/pull-requests.ts
+++ b/src/dictionary/entries/pull-requests.ts
@@ -304,6 +304,15 @@ export const pullRequestEntries: DictionaryEntry[] = [
     // === Hover Entries ===
     {
         type: 'hover',
+        id: 'hover-create-pr-button',
+        selector: 'button.btn-primary.js-details-target, a.btn-primary[href*="/compare"], a.btn-primary[href*="/pull/new"], form[action*="/pull/create"] .btn-primary',
+        title: { ja: 'Create pull request' },
+        description: {
+            ja: 'プルリクエストを作成するボタンです．変更をレビュー依頼したい時に使います．',
+        },
+    },
+    {
+        type: 'hover',
         id: 'hover-pr-nav',
         selector: 'nav a[href*="/pulls"], a.js-selected-navigation-item[data-tab-item="i1pull-requests-tab"], a[data-tab-item*="pull"], [aria-label*="Pull Request"]',
         title: { ja: 'プルリクエスト' },


### PR DESCRIPTION
### **User description**
Integrates the hardcoded 'Create pull request' tooltip into the generic hover dictionary system.

Changes:
- **`src/content/index.ts`**: Removed hardcoded `mouseover`/`mouseout` listeners and local tooltip functions.
- **`src/dictionary/entries/pull-requests.ts`**: Added a new `HoverEntry` for the Create PR button, utilizing specific selectors (`.js-details-target`, `href*="/compare"`, etc.) to target the button accurately across different contexts (Repo home, Compare page, Branches).
- **`src/content/hover.ts`**: Updated `handleMouseOver` to check `target instanceof Element` instead of `HTMLElement`. This ensures that events originating from SVG icons (common in buttons) are correctly delegated to the closest matching ancestor selector.

This change eliminates code duplication and centralizes tooltip definitions in the dictionary.

---
*PR created automatically by Jules for task [13200709591589363308](https://jules.google.com/task/13200709591589363308) started by @is0692vs*


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Integrated hardcoded 'Create pull request' tooltip into generic hover system

- Removed duplicate tooltip implementation and centralized definitions

- Fixed SVG icon event delegation by checking `Element` instead of `HTMLElement`

- Added comprehensive selectors for PR button across different contexts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded tooltip<br/>in index.ts"] -->|"Remove"| B["Generic hover<br/>system"]
  C["SVG icon<br/>events"] -->|"Fix with Element<br/>check"| D["Proper event<br/>delegation"]
  E["PR button<br/>selectors"] -->|"Add to<br/>dictionary"| F["pull-requests.ts<br/>HoverEntry"]
  B --> F
  D --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hover.ts</strong><dd><code>Fix SVG icon event delegation in hover handler</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/content/hover.ts

<ul><li>Changed target type check from <code>HTMLElement</code> to <code>Element</code> to support SVG <br>icon children<br> <li> Enables proper event delegation for buttons containing SVG elements</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/gittohabu/pull/26/files#diff-936795ed88633ce6b21d481a0d07a4f875438d66cf362856e6270fb9a3742faf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Remove hardcoded tooltip implementation and listeners</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/content/index.ts

<ul><li>Removed hardcoded <code>showTooltip()</code> and <code>hideTooltip()</code> functions<br> <li> Removed hardcoded <code>mouseover</code>/<code>mouseout</code> event listeners for Create PR <br>button<br> <li> Removed unused <code>TooltipOptions</code> interface and <code>tooltipElement</code> variable<br> <li> Cleaned up TODO comment referencing tooltip UI integration</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/gittohabu/pull/26/files#diff-26b000da29e073939f33a4e8f19ecf21da37a1f5942896954ea3f2af231962ff">+0/-94</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pull-requests.ts</strong><dd><code>Add HoverEntry for Create PR button tooltip</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/dictionary/entries/pull-requests.ts

<ul><li>Added new <code>HoverEntry</code> for 'Create pull request' button with id <br><code>hover-create-pr-button</code><br> <li> Implemented comprehensive selector targeting button across contexts: <br>repo home, compare page, branches, and pull creation forms<br> <li> Included Japanese title and description matching original hardcoded <br>tooltip text</ul>


</details>


  </td>
  <td><a href="https://github.com/Hiroki-org/gittohabu/pull/26/files#diff-25b0d7b68cf225a27b06dc832874b50b2eef4fe584b567f60043dd585ea08144">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

