### PR TITLE
⚡ Optimize flushPendingNodes to avoid redundant array allocations

### DIFF
--- a/scripts/benchmark-observer.ts
+++ b/scripts/benchmark-observer.ts
@@ -1,0 +1,96 @@
+class MockNode {
+  parentNode: MockNode | null = null;
+  isConnected = true;
+  nodeType = 1; // ELEMENT_NODE
+}
+
+const numNodes = 10000;
+const currentPending = new Set<MockNode>();
+const nodes: MockNode[] = [];
+
+for (let i = 0; i < numNodes; i++) {
+  const node = new MockNode();
+  if (i > 0) {
+    node.parentNode = nodes[Math.floor(Math.random() * i)];
+  }
+  nodes.push(node);
+  currentPending.add(node);
+}
+
+const currentPendingArray = Array.from(currentPending);
+
+function runBaseline() {
+  const ancestorCache = new Map<MockNode, boolean>();
+
+  function hasPendingAncestor(node: MockNode | null): boolean {
+    if (!node) return false;
+    if (ancestorCache.has(node)) return ancestorCache.get(node)!;
+
+    let result = false;
+    if (currentPending.has(node)) {
+      result = true;
+    } else {
+      result = hasPendingAncestor(node.parentNode);
+    }
+
+    ancestorCache.set(node, result);
+    return result;
+  }
+
+  const nodesArr = Array.from(currentPending);
+  const filteredNodes = nodesArr.filter((node) => {
+    if (!node.isConnected) return false;
+    return !hasPendingAncestor(node.parentNode);
+  });
+
+  let count = 0;
+  for (const node of filteredNodes) {
+    if (!node.isConnected) continue;
+    count++;
+  }
+  return count;
+}
+
+function runOptimized() {
+  const ancestorCache = new Map<MockNode, boolean>();
+
+  function hasPendingAncestor(node: MockNode | null): boolean {
+    if (!node) return false;
+    if (ancestorCache.has(node)) return ancestorCache.get(node)!;
+
+    let result = false;
+    if (currentPending.has(node)) {
+      result = true;
+    } else {
+      result = hasPendingAncestor(node.parentNode);
+    }
+
+    ancestorCache.set(node, result);
+    return result;
+  }
+
+  let count = 0;
+  for (const node of currentPending) {
+    if (!node.isConnected) continue;
+    if (hasPendingAncestor(node.parentNode)) continue;
+    count++;
+  }
+  return count;
+}
+
+// Warm up
+for (let i = 0; i < 100; i++) {
+  runBaseline();
+  runOptimized();
+}
+
+const baselineStart = performance.now();
+for (let i = 0; i < 100; i++) runBaseline();
+const baselineEnd = performance.now();
+
+const optimizedStart = performance.now();
+for (let i = 0; i < 100; i++) runOptimized();
+const optimizedEnd = performance.now();
+
+console.log(`Baseline: ${baselineEnd - baselineStart}ms`);
+console.log(`Optimized: ${optimizedEnd - optimizedStart}ms`);

--- a/src/content/observer.ts
+++ b/src/content/observer.ts
@@ -12,8 +12,6 @@ function flushPendingNodes(): void {
   const currentPending = pendingNodes;
   pendingNodes = new Set<Node>();
 
-  const nodes = Array.from(currentPending);
-
   // 祖先要素のチェック結果をキャッシュするMap
   const ancestorCache = new Map<Node, boolean>();
 
@@ -41,19 +39,10 @@ function flushPendingNodes(): void {
     return result;
   }
 
-  // 祖先要素がcurrentPendingに含まれている場合は、親の処理でカバーされるため除外する
-  const filteredNodes = nodes.filter((node) => {
-    // 切断されたノードはスキップ
-    if (!node.isConnected) {
-      return false;
-    }
-    // 親から順に祖先をチェック
-    return !hasPendingAncestor(node.parentNode);
-  });
-
-  for (const node of filteredNodes) {
-    // 処理前に再度接続状態を確認
+  for (const node of currentPending) {
+    // 切断されたノードはスキップ（親のチェックより先に実行して不要な処理を回避）
     if (!node.isConnected) continue;
+    if (hasPendingAncestor(node.parentNode)) continue;
 
     if (node.nodeType === Node.ELEMENT_NODE) {
       replaceTextInElement(node as Element, currentUrl);


### PR DESCRIPTION
💡 **What:** Eliminated the intermediate `Array.from` allocation and the `filter` callback block in `flushPendingNodes` (in `src/content/observer.ts`). The function now iterates directly over the `currentPending` Set using a `for...of` loop. I also moved the `!node.isConnected` check to the top of the loop to ensure short-circuiting happens before more expensive DOM tree traversals (like `hasPendingAncestor`).

🎯 **Why:** To reduce unnecessary memory allocations (the array) and its subsequent garbage collection overhead. This helps keep memory usage stable and performance smoother during high-frequency DOM mutations.

📊 **Measured Improvement:** Baseline was ~152ms. Optimized is ~151ms. The benchmark improvement is minor in CPU time (~1ms over 100 iterations of 10,000 nodes), however, the primary gain is structural: eliminating the `Array` creation reduces GC pressure and memory spikes which are difficult to quantify with simple timing benchmarks but crucial for content script performance.

---
*PR created automatically by Jules for task [5340150905859298965](https://jules.google.com/task/5340150905859298965) started by @is0692vs*